### PR TITLE
Added check for valid SQL before running fetchAll.  

### DIFF
--- a/src/Server/Resource/DoctrineResourceFactory.php
+++ b/src/Server/Resource/DoctrineResourceFactory.php
@@ -105,13 +105,17 @@ class DoctrineResourceFactory implements AbstractFactoryInterface
             ? $container->get($doctrineConnectedConfig['entity_factory'])
             : null;
 
+        $displayExceptions = $config['view_manager']['display_exceptions'] ?? false;
         $hydrator = $this->loadHydrator($container, $doctrineConnectedConfig, $doctrineHydratorConfig);
         $queryProviders = $this->loadQueryProviders($container, $doctrineConnectedConfig, $objectManager);
         $queryCreateFilter = $this->loadQueryCreateFilter($container, $doctrineConnectedConfig, $objectManager);
         $configuredListeners = $this->loadConfiguredListeners($container, $doctrineConnectedConfig);
 
-        /** @var DoctrineResource $listener */
-        $listener = new $resourceClass($entityFactory);
+        /**
+         * @var DoctrineResource $listener
+         * @var bool $displayExceptions
+        */
+        $listener = new $resourceClass($entityFactory, $displayExceptions);
         $listener->setSharedEventManager($container->get('Application')->getEventManager()->getSharedManager());
         $listener->setObjectManager($objectManager);
         $listener->setHydrator($hydrator);


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

Fixes https://github.com/laminas-api-tools/api-tools-doctrine-querybuilder/issues/3

api-tools-doctrine-querybuilder allows a user to inject invalid sql into a QueryBuilder.  This fix calls the collection adapter query object with `getSQL()` which triggers the query to `parse()` https://github.com/doctrine/orm/blob/master/lib/Doctrine/ORM/Query.php#L181 and throws an exception if the query is invalid.  This is caught and re-thrown as a DomainException fro ApiProblem.

Unit test included which injects invalid sql to trigger custom 500 error.

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
