### PR TITLE
Provide Psalm integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,9 @@
         "mongodb/mongodb": "^1.1.0",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^9.3",
-        "symfony/yaml": "^2.3 || ^3.0 || ^4.0 || ^5.0"
+        "psalm/plugin-phpunit": "^0.16.1",
+        "symfony/yaml": "^2.3 || ^3.0 || ^4.0 || ^5.0",
+        "vimeo/psalm": "^4.8"
     },
     "conflict": {
         "doctrine/dbal": "<2.12.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a85333c4e670560db684bcb1467333db",
+    "content-hash": "c73745931925217c5ec6217e8aa8ccfa",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -5431,6 +5431,172 @@
             "time": "2020-11-11T14:05:46+00:00"
         },
         {
+            "name": "amphp/amp",
+            "version": "v2.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/amp.git",
+                "reference": "efca2b32a7580087adb8aabbff6be1dc1bb924a9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/efca2b32a7580087adb8aabbff6be1dc1bb924a9",
+                "reference": "efca2b32a7580087adb8aabbff6be1dc1bb924a9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "dev-master",
+                "amphp/phpunit-util": "^1",
+                "ext-json": "*",
+                "jetbrains/phpstorm-stubs": "^2019.3",
+                "phpunit/phpunit": "^6.0.9 | ^7",
+                "psalm/phar": "^3.11@dev",
+                "react/promise": "^2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Amp\\": "lib"
+                },
+                "files": [
+                    "lib/functions.php",
+                    "lib/Internal/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Bob Weinand",
+                    "email": "bobwei9@hotmail.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A non-blocking concurrency framework for PHP applications.",
+            "homepage": "http://amphp.org/amp",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "awaitable",
+                "concurrency",
+                "event",
+                "event-loop",
+                "future",
+                "non-blocking",
+                "promise"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/amphp",
+                "issues": "https://github.com/amphp/amp/issues",
+                "source": "https://github.com/amphp/amp/tree/v2.5.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-01-10T17:06:37+00:00"
+        },
+        {
+            "name": "amphp/byte-stream",
+            "version": "v1.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/byte-stream.git",
+                "reference": "acbd8002b3536485c997c4e019206b3f10ca15bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/acbd8002b3536485c997c4e019206b3f10ca15bd",
+                "reference": "acbd8002b3536485c997c4e019206b3f10ca15bd",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^2",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "dev-master",
+                "amphp/phpunit-util": "^1.4",
+                "friendsofphp/php-cs-fixer": "^2.3",
+                "jetbrains/phpstorm-stubs": "^2019.3",
+                "phpunit/phpunit": "^6 || ^7 || ^8",
+                "psalm/phar": "^3.11.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Amp\\ByteStream\\": "lib"
+                },
+                "files": [
+                    "lib/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A stream abstraction to make working with non-blocking I/O simple.",
+            "homepage": "http://amphp.org/byte-stream",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "io",
+                "non-blocking",
+                "stream"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/amphp",
+                "issues": "https://github.com/amphp/byte-stream/issues",
+                "source": "https://github.com/amphp/byte-stream/tree/v1.8.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-03-30T17:13:30+00:00"
+        },
+        {
             "name": "composer/package-versions-deprecated",
             "version": "1.11.99.2",
             "source": {
@@ -5504,6 +5670,151 @@
             "time": "2021-05-24T07:46:03+00:00"
         },
         {
+            "name": "composer/semver",
+            "version": "3.2.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "31f3ea725711245195f62e54ffa402d8ef2fdba9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/31f3ea725711245195f62e54ffa402d8ef2fdba9",
+                "reference": "31f3ea725711245195f62e54ffa402d8ef2fdba9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^0.12.54",
+                "symfony/phpunit-bridge": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/semver/issues",
+                "source": "https://github.com/composer/semver/tree/3.2.5"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-24T12:41:47+00:00"
+        },
+        {
+            "name": "composer/xdebug-handler",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/xdebug-handler.git",
+                "reference": "964adcdd3a28bf9ed5d9ac6450064e0d71ed7496"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/964adcdd3a28bf9ed5d9ac6450064e0d71ed7496",
+                "reference": "964adcdd3a28bf9ed5d9ac6450064e0d71ed7496",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0",
+                "psr/log": "^1.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^0.12.55",
+                "symfony/phpunit-bridge": "^4.2 || ^5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Composer\\XdebugHandler\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Stevenson",
+                    "email": "john-stevenson@blueyonder.co.uk"
+                }
+            ],
+            "description": "Restarts a process without Xdebug.",
+            "keywords": [
+                "Xdebug",
+                "performance"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/xdebug-handler/issues",
+                "source": "https://github.com/composer/xdebug-handler/tree/2.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-05T19:37:51+00:00"
+        },
+        {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
             "version": "v0.7.1",
             "source": {
@@ -5572,6 +5883,43 @@
                 "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
             },
             "time": "2020-12-07T18:04:37+00:00"
+        },
+        {
+            "name": "dnoegel/php-xdg-base-dir",
+            "version": "v0.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dnoegel/php-xdg-base-dir.git",
+                "reference": "8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dnoegel/php-xdg-base-dir/zipball/8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd",
+                "reference": "8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~7.0|~6.0|~5.0|~4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "XdgBaseDir\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "implementation of xdg base directory specification for php",
+            "support": {
+                "issues": "https://github.com/dnoegel/php-xdg-base-dir/issues",
+                "source": "https://github.com/dnoegel/php-xdg-base-dir/tree/v0.1.1"
+            },
+            "time": "2019-12-04T15:06:13+00:00"
         },
         {
             "name": "doctrine/dbal",
@@ -6195,6 +6543,107 @@
                 "source": "https://github.com/doctrine/orm/tree/2.7.5"
             },
             "time": "2020-12-03T08:52:14+00:00"
+        },
+        {
+            "name": "felixfbecker/advanced-json-rpc",
+            "version": "v3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/felixfbecker/php-advanced-json-rpc.git",
+                "reference": "b5f37dbff9a8ad360ca341f3240dc1c168b45447"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/felixfbecker/php-advanced-json-rpc/zipball/b5f37dbff9a8ad360ca341f3240dc1c168b45447",
+                "reference": "b5f37dbff9a8ad360ca341f3240dc1c168b45447",
+                "shasum": ""
+            },
+            "require": {
+                "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
+                "php": "^7.1 || ^8.0",
+                "phpdocumentor/reflection-docblock": "^4.3.4 || ^5.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "AdvancedJsonRpc\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Felix Becker",
+                    "email": "felix.b@outlook.com"
+                }
+            ],
+            "description": "A more advanced JSONRPC implementation",
+            "support": {
+                "issues": "https://github.com/felixfbecker/php-advanced-json-rpc/issues",
+                "source": "https://github.com/felixfbecker/php-advanced-json-rpc/tree/v3.2.1"
+            },
+            "time": "2021-06-11T22:34:44+00:00"
+        },
+        {
+            "name": "felixfbecker/language-server-protocol",
+            "version": "1.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/felixfbecker/php-language-server-protocol.git",
+                "reference": "9d846d1f5cf101deee7a61c8ba7caa0a975cd730"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/felixfbecker/php-language-server-protocol/zipball/9d846d1f5cf101deee7a61c8ba7caa0a975cd730",
+                "reference": "9d846d1f5cf101deee7a61c8ba7caa0a975cd730",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "*",
+                "squizlabs/php_codesniffer": "^3.1",
+                "vimeo/psalm": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "LanguageServerProtocol\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Felix Becker",
+                    "email": "felix.b@outlook.com"
+                }
+            ],
+            "description": "PHP classes for the Language Server Protocol",
+            "keywords": [
+                "language",
+                "microsoft",
+                "php",
+                "server"
+            ],
+            "support": {
+                "issues": "https://github.com/felixfbecker/php-language-server-protocol/issues",
+                "source": "https://github.com/felixfbecker/php-language-server-protocol/tree/1.5.1"
+            },
+            "time": "2021-02-22T14:02:09+00:00"
         },
         {
             "name": "jean85/pretty-package-versions",
@@ -7094,6 +7543,110 @@
             "time": "2020-11-13T09:40:50+00:00"
         },
         {
+            "name": "netresearch/jsonmapper",
+            "version": "v4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cweiske/jsonmapper.git",
+                "reference": "8bbc021a8edb2e4a7ea2f8ad4fa9ec9dce2fcb8d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/8bbc021a8edb2e4a7ea2f8ad4fa9ec9dce2fcb8d",
+                "reference": "8bbc021a8edb2e4a7ea2f8ad4fa9ec9dce2fcb8d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-spl": "*",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~7.5 || ~8.0 || ~9.0",
+                "squizlabs/php_codesniffer": "~3.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "JsonMapper": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "OSL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Weiske",
+                    "email": "cweiske@cweiske.de",
+                    "homepage": "http://github.com/cweiske/jsonmapper/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Map nested JSON structures onto PHP classes",
+            "support": {
+                "email": "cweiske@cweiske.de",
+                "issues": "https://github.com/cweiske/jsonmapper/issues",
+                "source": "https://github.com/cweiske/jsonmapper/tree/v4.0.0"
+            },
+            "time": "2020-12-01T19:48:11+00:00"
+        },
+        {
+            "name": "openlss/lib-array2xml",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nullivex/lib-array2xml.git",
+                "reference": "a91f18a8dfc69ffabe5f9b068bc39bb202c81d90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nullivex/lib-array2xml/zipball/a91f18a8dfc69ffabe5f9b068bc39bb202c81d90",
+                "reference": "a91f18a8dfc69ffabe5f9b068bc39bb202c81d90",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "LSS": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Bryan Tong",
+                    "email": "bryan@nullivex.com",
+                    "homepage": "https://www.nullivex.com"
+                },
+                {
+                    "name": "Tony Butler",
+                    "email": "spudz76@gmail.com",
+                    "homepage": "https://www.nullivex.com"
+                }
+            ],
+            "description": "Array2XML conversion library credit to lalit.org",
+            "homepage": "https://www.nullivex.com",
+            "keywords": [
+                "array",
+                "array conversion",
+                "xml",
+                "xml conversion"
+            ],
+            "support": {
+                "issues": "https://github.com/nullivex/lib-array2xml/issues",
+                "source": "https://github.com/nullivex/lib-array2xml/tree/master"
+            },
+            "time": "2019-03-29T20:06:56+00:00"
+        },
+        {
             "name": "phar-io/manifest",
             "version": "2.0.1",
             "source": {
@@ -7951,6 +8504,66 @@
                 }
             ],
             "time": "2021-06-23T05:14:38+00:00"
+        },
+        {
+            "name": "psalm/plugin-phpunit",
+            "version": "0.16.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/psalm/psalm-plugin-phpunit.git",
+                "reference": "5dd3be04f37a857d52880ef6af2524a441dfef24"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/psalm/psalm-plugin-phpunit/zipball/5dd3be04f37a857d52880ef6af2524a441dfef24",
+                "reference": "5dd3be04f37a857d52880ef6af2524a441dfef24",
+                "shasum": ""
+            },
+            "require": {
+                "composer/package-versions-deprecated": "^1.10",
+                "composer/semver": "^1.4 || ^2.0 || ^3.0",
+                "ext-simplexml": "*",
+                "php": "^7.1 || ^8.0",
+                "vimeo/psalm": "dev-master || dev-4.x || ^4.5"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<7.5"
+            },
+            "require-dev": {
+                "codeception/codeception": "^4.0.3",
+                "php": "^7.3 || ^8.0",
+                "phpunit/phpunit": "^7.5 || ^8.0 || ^9.0",
+                "squizlabs/php_codesniffer": "^3.3.1",
+                "weirdan/codeception-psalm-module": "^0.11.0",
+                "weirdan/prophecy-shim": "^1.0 || ^2.0"
+            },
+            "type": "psalm-plugin",
+            "extra": {
+                "psalm": {
+                    "pluginClass": "Psalm\\PhpUnitPlugin\\Plugin"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psalm\\PhpUnitPlugin\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Brown",
+                    "email": "github@muglug.com"
+                }
+            ],
+            "description": "Psalm plugin for PHPUnit",
+            "support": {
+                "issues": "https://github.com/psalm/psalm-plugin-phpunit/issues",
+                "source": "https://github.com/psalm/psalm-plugin-phpunit/tree/0.16.1"
+            },
+            "time": "2021-06-18T23:56:46+00:00"
         },
         {
             "name": "psr/log",
@@ -9209,6 +9822,111 @@
             "time": "2020-07-12T23:59:07+00:00"
         },
         {
+            "name": "vimeo/psalm",
+            "version": "4.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vimeo/psalm.git",
+                "reference": "f73f2299dbc59a3e6c4d66cff4605176e728ee69"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/f73f2299dbc59a3e6c4d66cff4605176e728ee69",
+                "reference": "f73f2299dbc59a3e6c4d66cff4605176e728ee69",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^2.4.2",
+                "amphp/byte-stream": "^1.5",
+                "composer/package-versions-deprecated": "^1.8.0",
+                "composer/semver": "^1.4 || ^2.0 || ^3.0",
+                "composer/xdebug-handler": "^1.1 || ^2.0",
+                "dnoegel/php-xdg-base-dir": "^0.1.1",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "felixfbecker/advanced-json-rpc": "^3.0.3",
+                "felixfbecker/language-server-protocol": "^1.5",
+                "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
+                "nikic/php-parser": "^4.10.5",
+                "openlss/lib-array2xml": "^1.0",
+                "php": "^7.1|^8",
+                "sebastian/diff": "^3.0 || ^4.0",
+                "symfony/console": "^3.4.17 || ^4.1.6 || ^5.0",
+                "webmozart/path-util": "^2.3"
+            },
+            "provide": {
+                "psalm/psalm": "self.version"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.2",
+                "brianium/paratest": "^4.0||^6.0",
+                "ext-curl": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpdocumentor/reflection-docblock": "^5",
+                "phpmyadmin/sql-parser": "5.1.0||dev-master",
+                "phpspec/prophecy": ">=1.9.0",
+                "phpunit/phpunit": "^9.0",
+                "psalm/plugin-phpunit": "^0.16",
+                "slevomat/coding-standard": "^7.0",
+                "squizlabs/php_codesniffer": "^3.5",
+                "symfony/process": "^4.3 || ^5.0",
+                "weirdan/phpunit-appveyor-reporter": "^1.0.0",
+                "weirdan/prophecy-shim": "^1.0 || ^2.0"
+            },
+            "suggest": {
+                "ext-igbinary": "^2.0.5"
+            },
+            "bin": [
+                "psalm",
+                "psalm-language-server",
+                "psalm-plugin",
+                "psalm-refactor",
+                "psalter"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev",
+                    "dev-3.x": "3.x-dev",
+                    "dev-2.x": "2.x-dev",
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psalm\\": "src/Psalm/"
+                },
+                "files": [
+                    "src/functions.php",
+                    "src/spl_object_id.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matthew Brown"
+                }
+            ],
+            "description": "A static analysis tool for finding errors in PHP applications",
+            "keywords": [
+                "code",
+                "inspection",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/vimeo/psalm/issues",
+                "source": "https://github.com/vimeo/psalm/tree/4.8.1"
+            },
+            "time": "2021-06-20T23:03:20+00:00"
+        },
+        {
             "name": "webimpress/coding-standard",
             "version": "1.2.2",
             "source": {
@@ -9262,6 +9980,56 @@
                 }
             ],
             "time": "2021-04-12T12:51:27+00:00"
+        },
+        {
+            "name": "webmozart/path-util",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/path-util.git",
+                "reference": "d939f7edc24c9a1bb9c0dee5cb05d8e859490725"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/path-util/zipball/d939f7edc24c9a1bb9c0dee5cb05d8e859490725",
+                "reference": "d939f7edc24c9a1bb9c0dee5cb05d8e859490725",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "webmozart/assert": "~1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\PathUtil\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "A robust cross-platform utility for normalizing, comparing and modifying file paths.",
+            "support": {
+                "issues": "https://github.com/webmozart/path-util/issues",
+                "source": "https://github.com/webmozart/path-util/tree/2.3.0"
+            },
+            "time": "2015-12-17T08:42:14+00:00"
         }
     ],
     "aliases": [],

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,0 +1,2480 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="4.8.1@f73f2299dbc59a3e6c4d66cff4605176e728ee69">
+  <file src="config/admin.config.php">
+    <UndefinedClass occurrences="25">
+      <code>Controller\DoctrineAutodiscovery</code>
+      <code>Controller\DoctrineAutodiscovery</code>
+      <code>Controller\DoctrineAutodiscovery</code>
+      <code>Controller\DoctrineAutodiscovery</code>
+      <code>Controller\DoctrineAutodiscovery</code>
+      <code>Controller\DoctrineAutodiscovery</code>
+      <code>Controller\DoctrineAutodiscovery</code>
+      <code>Controller\DoctrineMetadataService</code>
+      <code>Controller\DoctrineMetadataService</code>
+      <code>Controller\DoctrineMetadataService</code>
+      <code>Controller\DoctrineMetadataService</code>
+      <code>Controller\DoctrineMetadataService</code>
+      <code>Controller\DoctrineRestService</code>
+      <code>Controller\DoctrineRestService</code>
+      <code>Controller\DoctrineRestService</code>
+      <code>Controller\DoctrineRestService</code>
+      <code>Controller\DoctrineRestService</code>
+      <code>Controller\DoctrineRpcService</code>
+      <code>Controller\DoctrineRpcService</code>
+      <code>Controller\DoctrineRpcService</code>
+      <code>Controller\DoctrineRpcService</code>
+      <code>Controller\DoctrineRpcService</code>
+      <code>DoctrineAutodiscovery</code>
+      <code>Server\Validator\NoObjectExists</code>
+      <code>Server\Validator\ObjectExists</code>
+    </UndefinedClass>
+  </file>
+  <file src="config/server.config.php">
+    <UndefinedClass occurrences="6">
+      <code>NoObjectExists</code>
+      <code>ObjectExists</code>
+      <code>Validator\NoObjectExists</code>
+      <code>Validator\NoObjectExists</code>
+      <code>Validator\ObjectExists</code>
+      <code>Validator\ObjectExists</code>
+    </UndefinedClass>
+  </file>
+  <file src="src/Admin/Controller/DoctrineAutodiscoveryController.php">
+    <MixedArgument occurrences="3">
+      <code>$adapter</code>
+      <code>$module</code>
+      <code>$version</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="3">
+      <code>$adapter</code>
+      <code>$module</code>
+      <code>$version</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="3">
+      <code>fromRoute</code>
+      <code>fromRoute</code>
+      <code>fromRoute</code>
+    </MixedMethodCall>
+    <PropertyNotSetInConstructor occurrences="5">
+      <code>DoctrineAutodiscoveryController</code>
+      <code>DoctrineAutodiscoveryController</code>
+      <code>DoctrineAutodiscoveryController</code>
+      <code>DoctrineAutodiscoveryController</code>
+      <code>DoctrineAutodiscoveryController</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="src/Admin/Controller/DoctrineAutodiscoveryControllerFactory.php">
+    <DeprecatedInterface occurrences="1">
+      <code>DoctrineAutodiscoveryControllerFactory</code>
+    </DeprecatedInterface>
+    <DeprecatedMethod occurrences="1">
+      <code>getServiceLocator</code>
+    </DeprecatedMethod>
+    <ParamNameMismatch occurrences="1">
+      <code>$container</code>
+    </ParamNameMismatch>
+  </file>
+  <file src="src/Admin/Model/DoctrineAutodiscoveryModel.php">
+    <MixedArgument occurrences="1">
+      <code>$mapping['fieldName']</code>
+    </MixedArgument>
+    <MixedArrayAccess occurrences="4">
+      <code>$mapping['fieldName']</code>
+      <code>$mapping['fieldName']</code>
+      <code>$mapping['type']</code>
+      <code>$validator['options']</code>
+    </MixedArrayAccess>
+    <MixedArrayAssignment occurrences="1">
+      <code>$validator['options']</code>
+    </MixedArrayAssignment>
+    <MixedAssignment occurrences="6">
+      <code>$field['filters']</code>
+      <code>$field['filters']</code>
+      <code>$field['validators'][]</code>
+      <code>$mapping</code>
+      <code>$validator</code>
+      <code>$validator['options']['max']</code>
+    </MixedAssignment>
+    <NoInterfaceProperties occurrences="1">
+      <code>$classMetadata-&gt;fieldMappings</code>
+    </NoInterfaceProperties>
+    <PossiblyFalseOperand occurrences="1">
+      <code>strrpos($classMetadata-&gt;getName(), '\\')</code>
+    </PossiblyFalseOperand>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>DoctrineAutodiscoveryModel</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="src/Admin/Model/DoctrineAutodiscoveryModelFactory.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$container</code>
+    </ArgumentTypeCoercion>
+  </file>
+  <file src="src/Admin/Model/DoctrineMetadataServiceEntity.php">
+    <ImplementedReturnTypeMismatch occurrences="1">
+      <code>$this</code>
+    </ImplementedReturnTypeMismatch>
+    <MissingConstructor occurrences="36">
+      <code>$associationMappings</code>
+      <code>$changeTrackingPolicy</code>
+      <code>$columnNames</code>
+      <code>$containsForeignIdentifier</code>
+      <code>$customGeneratorDefinition</code>
+      <code>$customRepositoryClassName</code>
+      <code>$discriminatorColumn</code>
+      <code>$discriminatorMap</code>
+      <code>$discriminatorValue</code>
+      <code>$entityListeners</code>
+      <code>$fieldMappings</code>
+      <code>$fieldNames</code>
+      <code>$generatorType</code>
+      <code>$idGenerator</code>
+      <code>$identifier</code>
+      <code>$inheritanceType</code>
+      <code>$isIdentifierComposite</code>
+      <code>$isMappedSuperclass</code>
+      <code>$isReadOnly</code>
+      <code>$isVersioned</code>
+      <code>$lifecycleCallbacks</code>
+      <code>$name</code>
+      <code>$namedNativeQueries</code>
+      <code>$namedQueries</code>
+      <code>$namespace</code>
+      <code>$namingStrategy</code>
+      <code>$parentClasses</code>
+      <code>$reflClass</code>
+      <code>$reflFields</code>
+      <code>$rootEntityName</code>
+      <code>$sequenceGeneratorDefinition</code>
+      <code>$sqlResultSetMappings</code>
+      <code>$subClasses</code>
+      <code>$table</code>
+      <code>$tableGeneratorDefinition</code>
+      <code>$versionField</code>
+    </MissingConstructor>
+    <MixedAssignment occurrences="37">
+      <code>$this-&gt;associationMappings</code>
+      <code>$this-&gt;changeTrackingPolicy</code>
+      <code>$this-&gt;columnNames</code>
+      <code>$this-&gt;containsForeignIdentifier</code>
+      <code>$this-&gt;customGeneratorDefinition</code>
+      <code>$this-&gt;customRepositoryClassName</code>
+      <code>$this-&gt;discriminatorColumn</code>
+      <code>$this-&gt;discriminatorMap</code>
+      <code>$this-&gt;discriminatorValue</code>
+      <code>$this-&gt;entityListeners</code>
+      <code>$this-&gt;fieldMappings</code>
+      <code>$this-&gt;fieldNames</code>
+      <code>$this-&gt;generatorType</code>
+      <code>$this-&gt;idGenerator</code>
+      <code>$this-&gt;identifier</code>
+      <code>$this-&gt;inheritanceType</code>
+      <code>$this-&gt;isIdentifierComposite</code>
+      <code>$this-&gt;isMappedSuperclass</code>
+      <code>$this-&gt;isReadOnly</code>
+      <code>$this-&gt;isVersioned</code>
+      <code>$this-&gt;lifecycleCallbacks</code>
+      <code>$this-&gt;name</code>
+      <code>$this-&gt;namedNativeQueries</code>
+      <code>$this-&gt;namedQueries</code>
+      <code>$this-&gt;namespace</code>
+      <code>$this-&gt;namingStrategy</code>
+      <code>$this-&gt;parentClasses</code>
+      <code>$this-&gt;reflClass</code>
+      <code>$this-&gt;reflFields</code>
+      <code>$this-&gt;rootEntityName</code>
+      <code>$this-&gt;sequenceGeneratorDefinition</code>
+      <code>$this-&gt;sqlResultSetMappings</code>
+      <code>$this-&gt;subClasses</code>
+      <code>$this-&gt;table</code>
+      <code>$this-&gt;tableGeneratorDefinition</code>
+      <code>$this-&gt;versionField</code>
+      <code>$value</code>
+    </MixedAssignment>
+    <ParamNameMismatch occurrences="1">
+      <code>$data</code>
+    </ParamNameMismatch>
+  </file>
+  <file src="src/Admin/Model/DoctrineMetadataServiceResource.php">
+    <InvalidStringClass occurrences="2">
+      <code>new $entityClass()</code>
+      <code>new $entityClass()</code>
+    </InvalidStringClass>
+    <LessSpecificReturnStatement occurrences="2">
+      <code>$metadataEntity</code>
+      <code>$return</code>
+    </LessSpecificReturnStatement>
+    <MissingConstructor occurrences="1">
+      <code>$serviceManager</code>
+    </MissingConstructor>
+    <MixedArgument occurrences="2">
+      <code>$objectManagerAlias</code>
+      <code>$objectManagerClass</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="4">
+      <code>$objectManager</code>
+      <code>$objectManager</code>
+      <code>$objectManagerAlias</code>
+      <code>$objectManagerClass</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="4">
+      <code>exchangeArray</code>
+      <code>exchangeArray</code>
+      <code>getMetadataFactory</code>
+      <code>getMetadataFactory</code>
+    </MixedMethodCall>
+    <MoreSpecificImplementedParamType occurrences="5">
+      <code>$data</code>
+      <code>$data</code>
+      <code>$entityClassName</code>
+      <code>$id</code>
+      <code>$id</code>
+    </MoreSpecificImplementedParamType>
+    <MoreSpecificReturnType occurrences="2">
+      <code>RestServiceEntity[]|ApiProblem</code>
+      <code>RestServiceEntity|ApiProblem</code>
+    </MoreSpecificReturnType>
+    <ParamNameMismatch occurrences="1">
+      <code>$entityClassName</code>
+    </ParamNameMismatch>
+  </file>
+  <file src="src/Admin/Model/DoctrineMetadataServiceResourceFactory.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$container</code>
+    </ArgumentTypeCoercion>
+  </file>
+  <file src="src/Admin/Model/DoctrineRestServiceEntity.php">
+    <MissingConstructor occurrences="2">
+      <code>$hydratorName</code>
+      <code>$objectManager</code>
+    </MissingConstructor>
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>$key</code>
+    </MixedArgumentTypeCoercion>
+    <MixedArrayAssignment occurrences="5">
+      <code>$data['by_value']</code>
+      <code>$data['hydrator_name']</code>
+      <code>$data['object_manager']</code>
+      <code>$data['strategies']</code>
+      <code>$data['use_generated_hydrator']</code>
+    </MixedArrayAssignment>
+    <MixedAssignment occurrences="7">
+      <code>$data</code>
+      <code>$this-&gt;byValue</code>
+      <code>$this-&gt;hydratorName</code>
+      <code>$this-&gt;hydratorStrategies</code>
+      <code>$this-&gt;objectManager</code>
+      <code>$this-&gt;useGeneratedHydrator</code>
+      <code>$value</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="1">
+      <code>array&lt;string, mixed&gt;</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>$data</code>
+    </MixedReturnStatement>
+    <NonInvariantDocblockPropertyType occurrences="1">
+      <code>$hydratorName</code>
+    </NonInvariantDocblockPropertyType>
+    <ParamNameMismatch occurrences="1">
+      <code>$data</code>
+    </ParamNameMismatch>
+  </file>
+  <file src="src/Admin/Model/DoctrineRestServiceModel.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>$this-&gt;events</code>
+    </DocblockTypeContradiction>
+    <ImplementedReturnTypeMismatch occurrences="1">
+      <code>self</code>
+    </ImplementedReturnTypeMismatch>
+    <MissingClosureParamType occurrences="1">
+      <code>$r</code>
+    </MissingClosureParamType>
+    <MixedArgument occurrences="43">
+      <code>$collectionClass</code>
+      <code>$collectionClass</code>
+      <code>$collectionClass</code>
+      <code>$config</code>
+      <code>$config</code>
+      <code>$configHydrator</code>
+      <code>$configKey</code>
+      <code>$configKey</code>
+      <code>$configResource</code>
+      <code>$config['api-tools-rest']</code>
+      <code>$config['api-tools-versioning']['uri']</code>
+      <code>$controllerService</code>
+      <code>$controllerService</code>
+      <code>$controllerService</code>
+      <code>$controllerService</code>
+      <code>$controllerService</code>
+      <code>$controllerService</code>
+      <code>$details-&gt;objectManager</code>
+      <code>$details-&gt;objectManager</code>
+      <code>$details-&gt;objectManager</code>
+      <code>$details-&gt;routeIdentifierName</code>
+      <code>$details-&gt;routeMatch</code>
+      <code>$details-&gt;serviceName</code>
+      <code>$entity-&gt;getArrayCopy()</code>
+      <code>$entityClass</code>
+      <code>$filter-&gt;filter($resourceName)</code>
+      <code>$filter-&gt;filter($this-&gt;module)</code>
+      <code>$filter-&gt;filter($this-&gt;module)</code>
+      <code>$module</code>
+      <code>$module</code>
+      <code>$module</code>
+      <code>$original-&gt;controllerServiceName</code>
+      <code>$resourceClass</code>
+      <code>$restCollectionClass</code>
+      <code>$restConfig</code>
+      <code>$restResourceClass</code>
+      <code>$routeName</code>
+      <code>$routeName</code>
+      <code>$routeName</code>
+      <code>$routeName</code>
+      <code>$service-&gt;resourceClass</code>
+      <code>$strategy</code>
+      <code>$update-&gt;hydratorName</code>
+    </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="3">
+      <code>$controllerService</code>
+      <code>$controllerService</code>
+      <code>$controllerService</code>
+    </MixedArgumentTypeCoercion>
+    <MixedArrayAccess occurrences="15">
+      <code>$configResource['hydrator']</code>
+      <code>$config['accept_whitelist']</code>
+      <code>$config['api-tools']</code>
+      <code>$config['api-tools-content-validation'][$entity-&gt;controllerServiceName]</code>
+      <code>$config['api-tools-hal']['metadata_map']</code>
+      <code>$config['api-tools-rest'][$entity-&gt;controllerServiceName]</code>
+      <code>$config['api-tools-rest'][$entity-&gt;controllerServiceName]</code>
+      <code>$config['api-tools-versioning']['uri']</code>
+      <code>$config['content_type_whitelist']</code>
+      <code>$config['controllers']</code>
+      <code>$config['doctrine-hydrator'][$configResource['hydrator']]</code>
+      <code>$config['doctrine-hydrator'][$hydratorName]</code>
+      <code>$config['router']['routes'][$routeName]['options']['route']</code>
+      <code>$restConfig['listener']</code>
+      <code>$restConfig['listener']</code>
+    </MixedArrayAccess>
+    <MixedArrayAssignment occurrences="3">
+      <code>$restConfig['controllerServiceName']</code>
+      <code>$restConfig['module']</code>
+      <code>$restConfig['resource_class']</code>
+    </MixedArrayAssignment>
+    <MixedArrayOffset occurrences="15">
+      <code>$config['api-tools']['doctrine-connected'][$entity-&gt;resourceClass]</code>
+      <code>$config['api-tools']['doctrine-connected'][$entity-&gt;resourceClass]</code>
+      <code>$config['api-tools-content-validation'][$entity-&gt;controllerServiceName]</code>
+      <code>$config['api-tools-hal']['metadata_map'][$entity-&gt;entityClass]</code>
+      <code>$config['api-tools-rest'][$entity-&gt;controllerServiceName]</code>
+      <code>$config['api-tools-rest'][$entity-&gt;controllerServiceName]</code>
+      <code>$config['doctrine-hydrator'][$configResource['hydrator']]</code>
+      <code>$config['doctrine-hydrator'][$configResource['hydrator']]</code>
+      <code>$config['doctrine-hydrator'][$hydratorName]</code>
+      <code>$config['router']['routes'][$routeName]</code>
+      <code>$patch[$configKey]</code>
+    </MixedArrayOffset>
+    <MixedAssignment occurrences="43">
+      <code>$acceptWhitelist</code>
+      <code>$collectionClass</code>
+      <code>$config</code>
+      <code>$config</code>
+      <code>$config</code>
+      <code>$config</code>
+      <code>$configHydrator</code>
+      <code>$configKey</code>
+      <code>$configKey</code>
+      <code>$configKey</code>
+      <code>$configResource</code>
+      <code>$config['api-tools-hal']['metadata_map'][$entityClass]['hydrator']</code>
+      <code>$contentTypeWhitelist</code>
+      <code>$controllerService</code>
+      <code>$controllerService</code>
+      <code>$entity</code>
+      <code>$hydratorName</code>
+      <code>$hydratorName</code>
+      <code>$hydratorStrategies</code>
+      <code>$module</code>
+      <code>$module</code>
+      <code>$module</code>
+      <code>$objectManager</code>
+      <code>$patch[$configKey]</code>
+      <code>$patch['hydrator']</code>
+      <code>$patch['object_manager']</code>
+      <code>$resource</code>
+      <code>$resourceClass</code>
+      <code>$restCollectionClass</code>
+      <code>$restConfig</code>
+      <code>$restConfig['resource_class']</code>
+      <code>$restResourceClass</code>
+      <code>$route</code>
+      <code>$route</code>
+      <code>$routeName</code>
+      <code>$routeName</code>
+      <code>$routeName</code>
+      <code>$service</code>
+      <code>$strategy</code>
+      <code>$uriKey</code>
+      <code>$validator</code>
+      <code>$whitelist</code>
+      <code>$whitelist</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="3">
+      <code>DoctrineRestServiceEntity|false</code>
+      <code>string</code>
+      <code>string</code>
+    </MixedInferredReturnType>
+    <MixedMethodCall occurrences="1">
+      <code>getArrayCopy</code>
+    </MixedMethodCall>
+    <MixedOperand occurrences="5">
+      <code>$module</code>
+      <code>$resource</code>
+      <code>$service</code>
+      <code>$service</code>
+      <code>$service</code>
+    </MixedOperand>
+    <MixedPropertyFetch occurrences="1">
+      <code>$entity-&gt;resourceClass</code>
+    </MixedPropertyFetch>
+    <MixedReturnStatement occurrences="3">
+      <code>$config['api-tools-rest'][$controllerServiceName]['collection_class']</code>
+      <code>$config['api-tools-rest'][$controllerServiceName]['entity_class']</code>
+      <code>$eventResults-&gt;last()</code>
+    </MixedReturnStatement>
+    <NullableReturnStatement occurrences="2">
+      <code>null</code>
+      <code>null</code>
+    </NullableReturnStatement>
+    <ParamNameMismatch occurrences="1">
+      <code>$events</code>
+    </ParamNameMismatch>
+    <PossiblyFalseArgument occurrences="7">
+      <code>$original</code>
+      <code>$original</code>
+      <code>$original</code>
+      <code>$original</code>
+      <code>$original</code>
+      <code>$service</code>
+      <code>$service</code>
+    </PossiblyFalseArgument>
+    <PossiblyInvalidPropertyFetch occurrences="1">
+      <code>$service-&gt;resourceClass</code>
+    </PossiblyInvalidPropertyFetch>
+    <PropertyNotSetInConstructor occurrences="4">
+      <code>$events</code>
+      <code>$renderer</code>
+      <code>$routeNameFilter</code>
+      <code>$serviceManager</code>
+    </PropertyNotSetInConstructor>
+    <RedundantConditionGivenDocblockType occurrences="2">
+      <code>$this-&gt;renderer instanceof PhpRenderer</code>
+      <code>$this-&gt;routeNameFilter instanceof FilterChain</code>
+    </RedundantConditionGivenDocblockType>
+    <TooManyArguments occurrences="1">
+      <code>trigger</code>
+    </TooManyArguments>
+    <UndefinedVariable occurrences="1">
+      <code>$response</code>
+    </UndefinedVariable>
+  </file>
+  <file src="src/Admin/Model/DoctrineRestServiceModelFactory.php">
+    <ImplementedReturnTypeMismatch occurrences="1">
+      <code>DoctrineRestServiceModel</code>
+    </ImplementedReturnTypeMismatch>
+    <MixedArrayAssignment occurrences="1">
+      <code>$this-&gt;models[$type][$module]</code>
+    </MixedArrayAssignment>
+    <MixedInferredReturnType occurrences="1">
+      <code>DoctrineRestServiceModel</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>$this-&gt;models[$type][$module]</code>
+    </MixedReturnStatement>
+    <PossiblyNullArgument occurrences="1">
+      <code>$moduleEntity</code>
+    </PossiblyNullArgument>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$serviceManager</code>
+    </PropertyNotSetInConstructor>
+    <UndefinedMethod occurrences="1">
+      <code>setSharedManager</code>
+    </UndefinedMethod>
+  </file>
+  <file src="src/Admin/Model/DoctrineRestServiceModelFactoryFactory.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$container</code>
+    </ArgumentTypeCoercion>
+    <MixedArgument occurrences="6">
+      <code>$container-&gt;get(ConfigResourceFactory::class)</code>
+      <code>$container-&gt;get(ModuleModel::class)</code>
+      <code>$container-&gt;get(ModulePathSpec::class)</code>
+      <code>$sharedEvents</code>
+      <code>ConfigResourceFactory::class</code>
+      <code>ConfigResourceFactory::class</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="1">
+      <code>$sharedEvents</code>
+    </MixedAssignment>
+    <UndefinedClass occurrences="2">
+      <code>ConfigResourceFactory</code>
+      <code>ConfigResourceFactory</code>
+    </UndefinedClass>
+  </file>
+  <file src="src/Admin/Model/DoctrineRestServiceResource.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>$this-&gt;model instanceof DoctrineRestServiceModel</code>
+    </DocblockTypeContradiction>
+    <InvalidReturnStatement occurrences="1">
+      <code>$this-&gt;model</code>
+    </InvalidReturnStatement>
+    <LessSpecificReturnStatement occurrences="2">
+      <code>$service</code>
+      <code>parent::fetch($id)</code>
+    </LessSpecificReturnStatement>
+    <MoreSpecificImplementedParamType occurrences="2">
+      <code>$data</code>
+      <code>$id</code>
+    </MoreSpecificImplementedParamType>
+    <MoreSpecificReturnType occurrences="2">
+      <code>DoctrineRestServiceEntity|ApiProblem</code>
+      <code>DoctrineRestServiceEntity|ApiProblem</code>
+    </MoreSpecificReturnType>
+    <PropertyNotSetInConstructor occurrences="7">
+      <code>DoctrineRestServiceResource</code>
+      <code>DoctrineRestServiceResource</code>
+      <code>DoctrineRestServiceResource</code>
+      <code>DoctrineRestServiceResource</code>
+      <code>DoctrineRestServiceResource</code>
+      <code>DoctrineRestServiceResource</code>
+      <code>DoctrineRestServiceResource</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="src/Admin/Model/DoctrineRestServiceResourceFactory.php">
+    <MixedArgument occurrences="3">
+      <code>$container-&gt;get(DoctrineRestServiceModelFactory::class)</code>
+      <code>$container-&gt;get(DocumentationModel::class)</code>
+      <code>$container-&gt;get(InputFilterModel::class)</code>
+    </MixedArgument>
+  </file>
+  <file src="src/Admin/Model/DoctrineRpcServiceModel.php">
+    <MixedArgument occurrences="12">
+      <code>$config['api-tools-rpc-doctrine-controller']</code>
+      <code>$config['api-tools-versioning']['uri']</code>
+      <code>$controllerService</code>
+      <code>$controllerService</code>
+      <code>$controllerService</code>
+      <code>$controllerService</code>
+      <code>$controllerService</code>
+      <code>$data['route_name']</code>
+      <code>$entity-&gt;controllerClass</code>
+      <code>$routeName</code>
+      <code>$serviceName</code>
+      <code>$serviceName</code>
+    </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="3">
+      <code>$controllerService</code>
+      <code>$controllerService</code>
+      <code>$controllerService</code>
+    </MixedArgumentTypeCoercion>
+    <MixedArrayAccess occurrences="8">
+      <code>$config[$routeName]</code>
+      <code>$config['api-tools-versioning']['uri']</code>
+      <code>$config['options']</code>
+      <code>$contentNegotiationConfig['accept_whitelist']</code>
+      <code>$contentNegotiationConfig['content_type_whitelist']</code>
+      <code>$contentNegotiationConfig['controllers']</code>
+      <code>$rpcConfig['http_methods']</code>
+      <code>$rpcConfig['route_name']</code>
+    </MixedArrayAccess>
+    <MixedArrayAssignment occurrences="4">
+      <code>$config['api-tools-content-negotiation'][$headerType]</code>
+      <code>$config['api-tools-content-negotiation']['controllers']</code>
+      <code>$config['api-tools-rpc'][$controllerService]</code>
+      <code>$config['router']['routes']</code>
+    </MixedArrayAssignment>
+    <MixedArrayOffset occurrences="1">
+      <code>$config['router']['routes'][$routeName]</code>
+    </MixedArrayOffset>
+    <MixedAssignment occurrences="15">
+      <code>$config</code>
+      <code>$config</code>
+      <code>$contentNegotiationConfig</code>
+      <code>$controllerData</code>
+      <code>$controllerService</code>
+      <code>$data['accept_whitelist']</code>
+      <code>$data['content_type_whitelist']</code>
+      <code>$data['http_methods']</code>
+      <code>$data['route_name']</code>
+      <code>$data['selector']</code>
+      <code>$fullClassName</code>
+      <code>$routeName</code>
+      <code>$routeName</code>
+      <code>$rpcConfig</code>
+      <code>$serviceName</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="2">
+      <code>false|string</code>
+      <code>string</code>
+    </MixedInferredReturnType>
+    <MixedPropertyFetch occurrences="1">
+      <code>$controllerData-&gt;service</code>
+    </MixedPropertyFetch>
+    <MixedReturnStatement occurrences="2">
+      <code>$config['options']['route']</code>
+      <code>$filter-&gt;filter($string)</code>
+    </MixedReturnStatement>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>$filter</code>
+    </PropertyNotSetInConstructor>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>$this-&gt;filter instanceof FilterChain</code>
+    </RedundantConditionGivenDocblockType>
+    <UndefinedClass occurrences="1">
+      <code>InvokableFactory</code>
+    </UndefinedClass>
+  </file>
+  <file src="src/Admin/Model/DoctrineRpcServiceModelFactory.php">
+    <ImplementedReturnTypeMismatch occurrences="1">
+      <code>DoctrineRpcServiceModel</code>
+    </ImplementedReturnTypeMismatch>
+    <MixedInferredReturnType occurrences="1">
+      <code>DoctrineRpcServiceModel</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>$this-&gt;models[$module]</code>
+    </MixedReturnStatement>
+    <PossiblyNullArgument occurrences="1">
+      <code>$moduleEntity</code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="src/Admin/Model/DoctrineRpcServiceModelFactoryFactory.php">
+    <MixedArgument occurrences="6">
+      <code>$configFactory</code>
+      <code>$moduleModel</code>
+      <code>$modulePathSpec</code>
+      <code>$sharedEvents</code>
+      <code>ConfigResourceFactory::class</code>
+      <code>ConfigResourceFactory::class</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="4">
+      <code>$configFactory</code>
+      <code>$moduleModel</code>
+      <code>$modulePathSpec</code>
+      <code>$sharedEvents</code>
+    </MixedAssignment>
+    <UndefinedClass occurrences="2">
+      <code>ConfigResourceFactory</code>
+      <code>ConfigResourceFactory</code>
+    </UndefinedClass>
+  </file>
+  <file src="src/Admin/Model/DoctrineRpcServiceResource.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>$this-&gt;model instanceof DoctrineRpcServiceModel</code>
+    </DocblockTypeContradiction>
+    <InvalidReturnStatement occurrences="1">
+      <code>$this-&gt;model</code>
+    </InvalidReturnStatement>
+    <InvalidScalarArgument occurrences="1">
+      <code>$e-&gt;getCode()</code>
+    </InvalidScalarArgument>
+    <LessSpecificReturnStatement occurrences="2">
+      <code>$service</code>
+      <code>parent::fetch($id)</code>
+    </LessSpecificReturnStatement>
+    <MoreSpecificImplementedParamType occurrences="2">
+      <code>$data</code>
+      <code>$id</code>
+    </MoreSpecificImplementedParamType>
+    <MoreSpecificReturnType occurrences="2">
+      <code>DoctrineRpcServiceEntity|ApiProblem</code>
+      <code>DoctrineRpcServiceEntity|ApiProblem</code>
+    </MoreSpecificReturnType>
+    <PossiblyInvalidArgument occurrences="1">
+      <code>$creationData['http_methods']</code>
+    </PossiblyInvalidArgument>
+    <PropertyNotSetInConstructor occurrences="7">
+      <code>DoctrineRpcServiceResource</code>
+      <code>DoctrineRpcServiceResource</code>
+      <code>DoctrineRpcServiceResource</code>
+      <code>DoctrineRpcServiceResource</code>
+      <code>DoctrineRpcServiceResource</code>
+      <code>DoctrineRpcServiceResource</code>
+      <code>DoctrineRpcServiceResource</code>
+    </PropertyNotSetInConstructor>
+    <TooManyArguments occurrences="1">
+      <code>createService</code>
+    </TooManyArguments>
+  </file>
+  <file src="src/Admin/Model/DoctrineRpcServiceResourceFactory.php">
+    <MixedArgument occurrences="4">
+      <code>$container-&gt;get('ControllerManager')</code>
+      <code>$container-&gt;get(DoctrineRpcServiceModelFactory::class)</code>
+      <code>$container-&gt;get(DocumentationModel::class)</code>
+      <code>$container-&gt;get(InputFilterModel::class)</code>
+    </MixedArgument>
+  </file>
+  <file src="src/Admin/Model/NewDoctrineServiceEntity.php">
+    <MissingConstructor occurrences="2">
+      <code>$hydratorName</code>
+      <code>$objectManager</code>
+    </MissingConstructor>
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>$key</code>
+    </MixedArgumentTypeCoercion>
+    <MixedArrayAssignment occurrences="5">
+      <code>$data['by_value']</code>
+      <code>$data['hydrator_name']</code>
+      <code>$data['object_manager']</code>
+      <code>$data['strategies']</code>
+      <code>$data['use_generated_hydrator']</code>
+    </MixedArrayAssignment>
+    <MixedAssignment occurrences="7">
+      <code>$data</code>
+      <code>$this-&gt;byValue</code>
+      <code>$this-&gt;hydratorName</code>
+      <code>$this-&gt;hydratorStrategies</code>
+      <code>$this-&gt;objectManager</code>
+      <code>$this-&gt;useGeneratedHydrator</code>
+      <code>$value</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="1">
+      <code>array&lt;string, mixed&gt;</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>$data</code>
+    </MixedReturnStatement>
+    <NonInvariantDocblockPropertyType occurrences="1">
+      <code>$hydratorName</code>
+    </NonInvariantDocblockPropertyType>
+    <ParamNameMismatch occurrences="1">
+      <code>$data</code>
+    </ParamNameMismatch>
+  </file>
+  <file src="src/Admin/Module.php">
+    <MixedInferredReturnType occurrences="1">
+      <code>array</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>include __DIR__ . '/../../config/admin.config.php'</code>
+    </MixedReturnStatement>
+  </file>
+  <file src="src/Server/Event/DoctrineResourceEvent.php">
+    <PropertyNotSetInConstructor occurrences="7">
+      <code>$data</code>
+      <code>$entityClassName</code>
+      <code>$entityId</code>
+      <code>$objectManager</code>
+      <code>$resourceEvent</code>
+      <code>DoctrineResourceEvent</code>
+      <code>DoctrineResourceEvent</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="src/Server/Event/Listener/CollectionListener.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$associationTargetClass</code>
+    </ArgumentTypeCoercion>
+    <DocblockTypeContradiction occurrences="1">
+      <code>! $metadata</code>
+    </DocblockTypeContradiction>
+    <InvalidPropertyAssignmentValue occurrences="3">
+      <code>$this-&gt;entityHydratorMap</code>
+      <code>$this-&gt;entityHydratorMap</code>
+      <code>[]</code>
+    </InvalidPropertyAssignmentValue>
+    <LessSpecificReturnStatement occurrences="2">
+      <code>$hydratorMap[$entityClass]</code>
+      <code>$this-&gt;entityHydratorMap[$entityClass]</code>
+    </LessSpecificReturnStatement>
+    <MixedArgument occurrences="14">
+      <code>$association</code>
+      <code>$association</code>
+      <code>$association</code>
+      <code>$association</code>
+      <code>$association</code>
+      <code>$event-&gt;getTarget()-&gt;getServiceManager()</code>
+      <code>$listener</code>
+      <code>$subEntityData</code>
+      <code>$subEntityData</code>
+      <code>$subEntityData</code>
+      <code>$this-&gt;entityCollectionValuedAssociations[$entity]</code>
+      <code>$this-&gt;getEntityHydratorMap()[$entityClass]</code>
+      <code>$this-&gt;getRootEntity()</code>
+      <code>$this-&gt;iterateEntity($this-&gt;getRootEntity(), $this-&gt;getObjectData(), $this-&gt;getInputFilter())</code>
+    </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="2">
+      <code>$data</code>
+      <code>$data</code>
+    </MixedArgumentTypeCoercion>
+    <MixedArrayAccess occurrences="2">
+      <code>$configParams['entity_class']</code>
+      <code>$config[DoctrineHydratorFactory::FACTORY_NAMESPACE]</code>
+    </MixedArrayAccess>
+    <MixedArrayOffset occurrences="2">
+      <code>$data[$association]</code>
+      <code>$this-&gt;entityHydratorMap[$configParams['entity_class']]</code>
+    </MixedArrayOffset>
+    <MixedAssignment occurrences="13">
+      <code>$association</code>
+      <code>$association</code>
+      <code>$config</code>
+      <code>$config</code>
+      <code>$configParams</code>
+      <code>$hydrator</code>
+      <code>$hydratorKey</code>
+      <code>$hydratorManager</code>
+      <code>$identifierValues[$identifierName]</code>
+      <code>$listener</code>
+      <code>$subEntityData</code>
+      <code>$subEntityData</code>
+      <code>$this-&gt;rootEntity</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="2">
+      <code>ArrayObject</code>
+      <code>ClassMetadata</code>
+    </MixedInferredReturnType>
+    <MixedMethodCall occurrences="2">
+      <code>getServiceManager</code>
+      <code>new $targetEntityClassName()</code>
+    </MixedMethodCall>
+    <MixedReturnStatement occurrences="2">
+      <code>$this-&gt;classMetadataMap[$entity]</code>
+      <code>$this-&gt;entityCollectionValuedAssociations[$entity]</code>
+    </MixedReturnStatement>
+    <MoreSpecificReturnType occurrences="1">
+      <code>AbstractHydrator|DoctrineObject</code>
+    </MoreSpecificReturnType>
+    <PossiblyFalsePropertyAssignmentValue occurrences="1">
+      <code>false</code>
+    </PossiblyFalsePropertyAssignmentValue>
+    <PossiblyInvalidArgument occurrences="2">
+      <code>$hydratorMap</code>
+      <code>$this-&gt;getAssociatedEntityInputFilter($association, $inputFilter)</code>
+    </PossiblyInvalidArgument>
+    <PossiblyInvalidArrayAccess occurrences="2">
+      <code>$hydratorMap[$entityClass]</code>
+      <code>$this-&gt;getEntityHydratorMap()[$entityClass]</code>
+    </PossiblyInvalidArrayAccess>
+    <PossiblyInvalidMethodCall occurrences="1">
+      <code>getServiceManager</code>
+    </PossiblyInvalidMethodCall>
+    <PossiblyNullArgument occurrences="3">
+      <code>$data</code>
+      <code>$event-&gt;getResourceEvent()-&gt;getInputFilter()</code>
+      <code>$this-&gt;getEntityHydratorMap()[$entityClass]</code>
+    </PossiblyNullArgument>
+    <PossiblyNullArrayAccess occurrences="2">
+      <code>$hydratorMap[$entityClass]</code>
+      <code>$this-&gt;getEntityHydratorMap()[$entityClass]</code>
+    </PossiblyNullArrayAccess>
+    <PossiblyUndefinedMethod occurrences="1">
+      <code>hydrate</code>
+    </PossiblyUndefinedMethod>
+    <PropertyNotSetInConstructor occurrences="5">
+      <code>$inputFilter</code>
+      <code>$objectData</code>
+      <code>$objectManager</code>
+      <code>$rootEntity</code>
+      <code>$serviceManager</code>
+    </PropertyNotSetInConstructor>
+    <RedundantConditionGivenDocblockType occurrences="3">
+      <code>$stripEmptyAssociations === true &amp;&amp; ! empty($data) &amp;&amp; is_array($data)</code>
+      <code>$this-&gt;entityHydratorMap === null</code>
+      <code>is_array($data)</code>
+    </RedundantConditionGivenDocblockType>
+    <TooManyArguments occurrences="1">
+      <code>getIdentifierFieldNames</code>
+    </TooManyArguments>
+  </file>
+  <file src="src/Server/Module.php">
+    <MixedAssignment occurrences="2">
+      <code>$serviceListener</code>
+      <code>$sm</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="1">
+      <code>array</code>
+    </MixedInferredReturnType>
+    <MixedMethodCall occurrences="3">
+      <code>addServiceManager</code>
+      <code>addServiceManager</code>
+      <code>get</code>
+    </MixedMethodCall>
+    <MixedReturnStatement occurrences="1">
+      <code>include __DIR__ . '/../../config/server.config.php'</code>
+    </MixedReturnStatement>
+  </file>
+  <file src="src/Server/Paginator/Adapter/DoctrineOdmAdapter.php">
+    <InvalidClass occurrences="4">
+      <code>Builder</code>
+      <code>Builder</code>
+      <code>Builder</code>
+      <code>Builder</code>
+    </InvalidClass>
+    <MixedInferredReturnType occurrences="2">
+      <code>array</code>
+      <code>count</code>
+    </MixedInferredReturnType>
+    <MixedMethodCall occurrences="2">
+      <code>count</code>
+      <code>toArray</code>
+    </MixedMethodCall>
+    <MixedReturnStatement occurrences="2">
+      <code>$queryBuilder-&gt;getQuery()-&gt;execute()-&gt;count()</code>
+      <code>$queryBuilder-&gt;getQuery()-&gt;execute()-&gt;toArray()</code>
+    </MixedReturnStatement>
+    <NullArgument occurrences="1">
+      <code>null</code>
+    </NullArgument>
+  </file>
+  <file src="src/Server/Paginator/Adapter/DoctrineOrmAdapter.php">
+    <MixedArgument occurrences="1">
+      <code>$this-&gt;cache[$offset]</code>
+    </MixedArgument>
+    <MixedArrayAssignment occurrences="1">
+      <code>$this-&gt;cache[$offset][$itemCountPerPage]</code>
+    </MixedArrayAssignment>
+    <MixedInferredReturnType occurrences="1">
+      <code>array</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="2">
+      <code>$this-&gt;cache[$offset][$itemCountPerPage]</code>
+      <code>$this-&gt;cache[$offset][$itemCountPerPage]</code>
+    </MixedReturnStatement>
+  </file>
+  <file src="src/Server/Query/CreateFilter/AbstractCreateFilter.php">
+    <MissingConstructor occurrences="1">
+      <code>$objectManager</code>
+    </MissingConstructor>
+  </file>
+  <file src="src/Server/Query/CreateFilter/Service/QueryCreateFilterManager.php">
+    <InvalidScalarArgument occurrences="1">
+      <code>$e-&gt;getCode()</code>
+    </InvalidScalarArgument>
+    <NonInvariantDocblockPropertyType occurrences="1">
+      <code>$instanceOf</code>
+    </NonInvariantDocblockPropertyType>
+  </file>
+  <file src="src/Server/Query/Provider/AbstractQueryProvider.php">
+    <MissingConstructor occurrences="2">
+      <code>$objectManager</code>
+      <code>$objectManager</code>
+    </MissingConstructor>
+    <MixedAssignment occurrences="1">
+      <code>$queryBuilder</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="4">
+      <code>from</code>
+      <code>getQuery</code>
+      <code>getSingleScalarResult</code>
+      <code>select</code>
+    </MixedMethodCall>
+    <MixedOperand occurrences="1">
+      <code>$identifier[0]</code>
+    </MixedOperand>
+    <MoreSpecificImplementedParamType occurrences="1">
+      <code>$queryBuilder</code>
+    </MoreSpecificImplementedParamType>
+    <PossiblyInvalidArgument occurrences="1">
+      <code>$queryBuilder-&gt;getQuery()</code>
+    </PossiblyInvalidArgument>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>createQueryBuilder</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="src/Server/Query/Provider/DefaultOdm.php">
+    <InvalidClass occurrences="2">
+      <code>$queryBuilder</code>
+      <code>Builder</code>
+    </InvalidClass>
+    <MixedAssignment occurrences="1">
+      <code>$queryBuilder</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="1">
+      <code>int</code>
+    </MixedInferredReturnType>
+    <MixedMethodCall occurrences="4">
+      <code>count</code>
+      <code>execute</code>
+      <code>find</code>
+      <code>getQuery</code>
+    </MixedMethodCall>
+    <MixedReturnStatement occurrences="1">
+      <code>$queryBuilder-&gt;getQuery()-&gt;execute()-&gt;count()</code>
+    </MixedReturnStatement>
+    <MoreSpecificImplementedParamType occurrences="2">
+      <code>$entityClass</code>
+      <code>$queryBuilder</code>
+    </MoreSpecificImplementedParamType>
+    <UndefinedInterfaceMethod occurrences="2">
+      <code>createQueryBuilder</code>
+      <code>createQueryBuilder</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="src/Server/Query/Provider/DefaultOrm.php">
+    <MixedAssignment occurrences="1">
+      <code>$queryBuilder</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="2">
+      <code>from</code>
+      <code>select</code>
+    </MixedMethodCall>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>createQueryBuilder</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="src/Server/Query/Provider/Service/QueryProviderManager.php">
+    <InvalidScalarArgument occurrences="1">
+      <code>$e-&gt;getCode()</code>
+    </InvalidScalarArgument>
+    <NonInvariantDocblockPropertyType occurrences="1">
+      <code>$instanceOf</code>
+    </NonInvariantDocblockPropertyType>
+  </file>
+  <file src="src/Server/Resource/DoctrineResource.php">
+    <ArgumentTypeCoercion occurrences="2">
+      <code>$entityClass</code>
+      <code>$this-&gt;getCollectionClass()</code>
+    </ArgumentTypeCoercion>
+    <DocblockTypeContradiction occurrences="6">
+      <code>! is_array($queryProviders)</code>
+      <code>$data instanceof ApiProblem</code>
+      <code>$this-&gt;events instanceof EventManagerInterface</code>
+      <code>$this-&gt;hydrator</code>
+      <code>is_string($this-&gt;eventIdentifier)</code>
+    </DocblockTypeContradiction>
+    <ImplementedReturnTypeMismatch occurrences="2">
+      <code>$this</code>
+      <code>ObjectManager|EntityManagerInterface</code>
+    </ImplementedReturnTypeMismatch>
+    <InvalidArgument occurrences="4">
+      <code>$data</code>
+      <code>$this-&gt;getEntityClass()</code>
+      <code>$this-&gt;getEntityClass()</code>
+      <code>true</code>
+    </InvalidArgument>
+    <InvalidReturnStatement occurrences="2">
+      <code>$result</code>
+      <code>$return</code>
+    </InvalidReturnStatement>
+    <InvalidScalarArgument occurrences="1">
+      <code>$this-&gt;getEntityClass()</code>
+    </InvalidScalarArgument>
+    <InvalidStringClass occurrences="1">
+      <code>new $entityClass()</code>
+    </InvalidStringClass>
+    <MixedArgument occurrences="11">
+      <code>$data</code>
+      <code>$data</code>
+      <code>$data</code>
+      <code>$data</code>
+      <code>$id</code>
+      <code>$id</code>
+      <code>$id</code>
+      <code>$id</code>
+      <code>$id</code>
+      <code>$queryBuilder</code>
+      <code>$result</code>
+    </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="3">
+      <code>$identifiers</code>
+      <code>$key</code>
+      <code>$key</code>
+    </MixedArgumentTypeCoercion>
+    <MixedArrayAccess occurrences="2">
+      <code>$row[$this-&gt;getEntityIdentifierName()]</code>
+      <code>$row[$this-&gt;getEntityIdentifierName()]</code>
+    </MixedArrayAccess>
+    <MixedAssignment occurrences="15">
+      <code>$criteria[$routeMatchParam]</code>
+      <code>$entity</code>
+      <code>$preEventData</code>
+      <code>$preEventData</code>
+      <code>$preEventData</code>
+      <code>$preEventData</code>
+      <code>$preEventData</code>
+      <code>$queryBuilder</code>
+      <code>$queryBuilder</code>
+      <code>$result</code>
+      <code>$result</code>
+      <code>$row</code>
+      <code>$row</code>
+      <code>$value</code>
+      <code>$value</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="3">
+      <code>QueryProviderInterface</code>
+      <code>array</code>
+      <code>object</code>
+    </MixedInferredReturnType>
+    <MixedMethodCall occurrences="15">
+      <code>andwhere</code>
+      <code>beginTransaction</code>
+      <code>beginTransaction</code>
+      <code>commit</code>
+      <code>commit</code>
+      <code>eq</code>
+      <code>expr</code>
+      <code>getQuery</code>
+      <code>getQuery</code>
+      <code>getRequest</code>
+      <code>getSingleResult</code>
+      <code>rollback</code>
+      <code>rollback</code>
+      <code>setParameter</code>
+      <code>toArray</code>
+    </MixedMethodCall>
+    <MixedReturnStatement occurrences="5">
+      <code>$entity</code>
+      <code>$queryProviders[$method]</code>
+      <code>$queryProviders['default']</code>
+      <code>$results-&gt;last()</code>
+      <code>$results-&gt;last()</code>
+    </MixedReturnStatement>
+    <MoreSpecificImplementedParamType occurrences="1">
+      <code>$data</code>
+    </MoreSpecificImplementedParamType>
+    <ParamNameMismatch occurrences="2">
+      <code>$data</code>
+      <code>$events</code>
+    </ParamNameMismatch>
+    <PossiblyInvalidArgument occurrences="2">
+      <code>$this-&gt;getObjectManager()</code>
+      <code>$this-&gt;getObjectManager()</code>
+    </PossiblyInvalidArgument>
+    <PossiblyInvalidMethodCall occurrences="3">
+      <code>getRequest</code>
+      <code>setCurrentPageNumber</code>
+      <code>setItemCountPerPage</code>
+    </PossiblyInvalidMethodCall>
+    <PossiblyNullArgument occurrences="1">
+      <code>$data</code>
+    </PossiblyNullArgument>
+    <PossiblyNullReference occurrences="2">
+      <code>getParams</code>
+      <code>getRequest</code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedMethod occurrences="8">
+      <code>getConnection</code>
+      <code>getConnection</code>
+      <code>getConnection</code>
+      <code>getConnection</code>
+      <code>getConnection</code>
+      <code>getConnection</code>
+      <code>setCurrentPageNumber</code>
+      <code>setItemCountPerPage</code>
+    </PossiblyUndefinedMethod>
+    <PropertyNotSetInConstructor occurrences="13">
+      <code>$entityIdentifierName</code>
+      <code>$events</code>
+      <code>$hydrator</code>
+      <code>$objectManager</code>
+      <code>$queryCreateFilter</code>
+      <code>$queryProviders</code>
+      <code>$routeIdentifierName</code>
+      <code>$sharedEventManager</code>
+      <code>DoctrineResource</code>
+      <code>DoctrineResource</code>
+      <code>DoctrineResource</code>
+      <code>DoctrineResource</code>
+      <code>DoctrineResource</code>
+    </PropertyNotSetInConstructor>
+    <RedundantConditionGivenDocblockType occurrences="3">
+      <code>is_array($this-&gt;eventIdentifier)</code>
+      <code>isset($this-&gt;eventIdentifier)</code>
+    </RedundantConditionGivenDocblockType>
+    <UndefinedDocblockClass occurrences="2">
+      <code>$routeMatch</code>
+      <code>$this-&gt;getEvent()-&gt;getRouteMatch()</code>
+    </UndefinedDocblockClass>
+    <UndefinedInterfaceMethod occurrences="2">
+      <code>$queryProviders</code>
+      <code>$queryProviders</code>
+    </UndefinedInterfaceMethod>
+    <UnusedMethodCall occurrences="1">
+      <code>getEntityClass</code>
+    </UnusedMethodCall>
+  </file>
+  <file src="src/Server/Resource/DoctrineResourceFactory.php">
+    <DeprecatedInterface occurrences="1">
+      <code>DoctrineResourceFactory</code>
+    </DeprecatedInterface>
+    <InvalidStringClass occurrences="1">
+      <code>new $resourceClass($entityFactory)</code>
+    </InvalidStringClass>
+    <MixedArgument occurrences="16">
+      <code>$config['object_manager']</code>
+      <code>$container-&gt;get('Application')-&gt;getEventManager()-&gt;getSharedManager()</code>
+      <code>$doctrineConnectedConfig</code>
+      <code>$doctrineConnectedConfig</code>
+      <code>$doctrineConnectedConfig['entity_factory']</code>
+      <code>$doctrineConnectedConfig['hydrator']</code>
+      <code>$doctrineConnectedConfig['object_manager']</code>
+      <code>$doctrineHydratorConfig</code>
+      <code>$entityClass</code>
+      <code>$listener</code>
+      <code>$objectManager</code>
+      <code>$objectManager</code>
+      <code>$objectManager</code>
+      <code>$resourceClass</code>
+      <code>$restConfig['entity_identifier_name']</code>
+      <code>$restConfig['route_identifier_name']</code>
+    </MixedArgument>
+    <MixedArrayAccess occurrences="11">
+      <code>$config['api-tools']</code>
+      <code>$config['api-tools']['doctrine-connected']</code>
+      <code>$config['api-tools']['doctrine-connected']</code>
+      <code>$config['api-tools-rest']</code>
+      <code>$config['doctrine-hydrator']</code>
+      <code>$doctrineConnectedConfig['entity_factory']</code>
+      <code>$doctrineConnectedConfig['object_manager']</code>
+      <code>$doctrineHydratorConfig[$doctrineConnectedConfig['hydrator']]['entity_class']</code>
+      <code>$restConfig['entity_identifier_name']</code>
+      <code>$restConfig['route_identifier_name']</code>
+      <code>$restControllerConfig['listener']</code>
+    </MixedArrayAccess>
+    <MixedArrayOffset occurrences="2">
+      <code>$doctrineHydratorConfig[$doctrineConnectedConfig['hydrator']]</code>
+      <code>$queryProviders[$method]</code>
+    </MixedArrayOffset>
+    <MixedAssignment occurrences="24">
+      <code>$config</code>
+      <code>$config</code>
+      <code>$configuredListener</code>
+      <code>$createFilterManager</code>
+      <code>$doctrineConnectedConfig</code>
+      <code>$doctrineHydratorConfig</code>
+      <code>$entityClass</code>
+      <code>$entityFactory</code>
+      <code>$filterManagerAlias</code>
+      <code>$hydratorManager</code>
+      <code>$listener</code>
+      <code>$listeners[]</code>
+      <code>$method</code>
+      <code>$objectManager</code>
+      <code>$plugin</code>
+      <code>$provider</code>
+      <code>$queryManager</code>
+      <code>$queryProviders[$method]</code>
+      <code>$queryProviders['default']</code>
+      <code>$queryProviders['default']</code>
+      <code>$resourceClass</code>
+      <code>$restConfig</code>
+      <code>$restControllerConfig</code>
+      <code>$viewHelpers</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="1">
+      <code>HydratorInterface</code>
+    </MixedInferredReturnType>
+    <MixedMethodCall occurrences="11">
+      <code>attach</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>getEventManager</code>
+      <code>getSharedManager</code>
+      <code>has</code>
+      <code>setObjectManager</code>
+    </MixedMethodCall>
+    <MixedReturnStatement occurrences="1">
+      <code>$hydratorManager-&gt;get($doctrineConnectedConfig['hydrator'])</code>
+    </MixedReturnStatement>
+    <NullableReturnStatement occurrences="3">
+      <code>null</code>
+      <code>null</code>
+      <code>null</code>
+    </NullableReturnStatement>
+    <ParamNameMismatch occurrences="2">
+      <code>$container</code>
+      <code>$container</code>
+    </ParamNameMismatch>
+  </file>
+  <file src="src/Server/Validator/NoObjectExistsFactory.php">
+    <DeprecatedInterface occurrences="1">
+      <code>NoObjectExistsFactory</code>
+    </DeprecatedInterface>
+    <DeprecatedMethod occurrences="1">
+      <code>getServiceLocator</code>
+    </DeprecatedMethod>
+    <MixedAssignment occurrences="1">
+      <code>$objectRepository</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="1">
+      <code>getRepository</code>
+    </MixedMethodCall>
+    <ParamNameMismatch occurrences="1">
+      <code>$container</code>
+    </ParamNameMismatch>
+    <PossiblyNullArgument occurrences="1">
+      <code>$options</code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="src/Server/Validator/ObjectExistsFactory.php">
+    <DeprecatedInterface occurrences="1">
+      <code>ObjectExistsFactory</code>
+    </DeprecatedInterface>
+    <DeprecatedMethod occurrences="1">
+      <code>getServiceLocator</code>
+    </DeprecatedMethod>
+    <MixedAssignment occurrences="1">
+      <code>$objectRepository</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="1">
+      <code>getRepository</code>
+    </MixedMethodCall>
+    <ParamNameMismatch occurrences="1">
+      <code>$container</code>
+    </ParamNameMismatch>
+    <PossiblyNullArgument occurrences="1">
+      <code>$options</code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="test/config/ORM/local.php">
+    <DeprecatedClass occurrences="1">
+      <code>Driver::class</code>
+    </DeprecatedClass>
+    <UndefinedClass occurrences="2">
+      <code>RevType</code>
+      <code>RevType</code>
+    </UndefinedClass>
+  </file>
+  <file src="test/config/testing.config.php">
+    <DeprecatedClass occurrences="1">
+      <code>Driver::class</code>
+    </DeprecatedClass>
+  </file>
+  <file src="test/src/Admin/Controller/DoctrineAutodiscoveryControllerFactoryTest.php">
+    <MixedArgument occurrences="1">
+      <code>$this-&gt;container-&gt;reveal()</code>
+    </MixedArgument>
+    <PossiblyUndefinedMethod occurrences="2">
+      <code>reveal</code>
+      <code>reveal</code>
+    </PossiblyUndefinedMethod>
+  </file>
+  <file src="test/src/Admin/Model/DoctrineAutodiscoveryModelFactoryTest.php">
+    <MixedArgument occurrences="3">
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+    </MixedArgument>
+    <MixedMethodCall occurrences="3">
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+    </MixedMethodCall>
+    <PossiblyUndefinedMethod occurrences="6">
+      <code>get</code>
+      <code>has</code>
+      <code>has</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+    </PossiblyUndefinedMethod>
+  </file>
+  <file src="test/src/Admin/Model/DoctrineAutodiscoveryModelTest.php">
+    <MixedArgument occurrences="6">
+      <code>$a['service_name']</code>
+      <code>$b['service_name']</code>
+      <code>$result[0]['fields']</code>
+      <code>$result[0]['fields']</code>
+      <code>$result[1]['fields']</code>
+      <code>$result[2]['fields']</code>
+    </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="1"/>
+    <MixedArrayAccess occurrences="12">
+      <code>$result[0]['entity_class']</code>
+      <code>$result[0]['entity_class']</code>
+      <code>$result[0]['fields']</code>
+      <code>$result[0]['fields']</code>
+      <code>$result[0]['service_name']</code>
+      <code>$result[0]['service_name']</code>
+      <code>$result[1]['entity_class']</code>
+      <code>$result[1]['fields']</code>
+      <code>$result[1]['service_name']</code>
+      <code>$result[2]['entity_class']</code>
+      <code>$result[2]['fields']</code>
+      <code>$result[2]['service_name']</code>
+    </MixedArrayAccess>
+    <NullArgument occurrences="4">
+      <code>null</code>
+      <code>null</code>
+      <code>null</code>
+      <code>null</code>
+    </NullArgument>
+    <RedundantConditionGivenDocblockType occurrences="2">
+      <code>assertIsArray</code>
+      <code>assertIsArray</code>
+    </RedundantConditionGivenDocblockType>
+    <UndefinedClass occurrences="4">
+      <code>Album</code>
+      <code>Artist</code>
+      <code>Meta</code>
+      <code>Product</code>
+    </UndefinedClass>
+  </file>
+  <file src="test/src/Admin/Model/DoctrineMetadata1Test.php">
+    <MixedArgument occurrences="7">
+      <code>$body</code>
+      <code>$body</code>
+      <code>$controllerServiceName</code>
+      <code>$em</code>
+      <code>$filter($mapping['fieldName'])</code>
+      <code>$this-&gt;getResponse()-&gt;getBody()</code>
+      <code>$this-&gt;getResponse()-&gt;getBody()</code>
+    </MixedArgument>
+    <MixedArrayAccess occurrences="7">
+      <code>$body['name']</code>
+      <code>$mapping['fieldName']</code>
+      <code>$mapping['fieldName']</code>
+      <code>$mapping['fieldName']</code>
+      <code>$mapping['sourceEntity']</code>
+      <code>$mapping['targetEntity']</code>
+      <code>$mapping['type']</code>
+    </MixedArrayAccess>
+    <MixedAssignment occurrences="8">
+      <code>$body</code>
+      <code>$body</code>
+      <code>$em</code>
+      <code>$em</code>
+      <code>$entityMetadata</code>
+      <code>$mapping</code>
+      <code>$metadataFactory</code>
+      <code>$rpcServiceResource</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="7">
+      <code>addHeaders</code>
+      <code>create</code>
+      <code>create</code>
+      <code>getMetadataFactory</code>
+      <code>getMetadataFor</code>
+      <code>setModuleName</code>
+      <code>setModuleName</code>
+    </MixedMethodCall>
+    <MixedOperand occurrences="1">
+      <code>$mapping['fieldName']</code>
+    </MixedOperand>
+    <MixedPropertyFetch occurrences="1">
+      <code>$entityMetadata-&gt;associationMappings</code>
+    </MixedPropertyFetch>
+    <UndefinedInterfaceMethod occurrences="3">
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getHeaders</code>
+    </UndefinedInterfaceMethod>
+    <UndefinedThisPropertyAssignment occurrences="1">
+      <code>$this-&gt;resource</code>
+    </UndefinedThisPropertyAssignment>
+  </file>
+  <file src="test/src/Admin/Model/DoctrineMetadata2Test.php">
+    <MixedArgument occurrences="5">
+      <code>$body</code>
+      <code>$this-&gt;getResponse()-&gt;getBody()</code>
+      <code>$this-&gt;getResponse()-&gt;getBody()</code>
+      <code>$this-&gt;getResponse()-&gt;getBody()</code>
+      <code>$this-&gt;getResponse()-&gt;getBody()</code>
+    </MixedArgument>
+    <MixedArrayAccess occurrences="8">
+      <code>$body['_embedded']</code>
+      <code>$body['_embedded']</code>
+      <code>$body['_embedded']</code>
+      <code>$body['_embedded']</code>
+      <code>$body['_embedded']</code>
+      <code>$body['controller_service_name']</code>
+      <code>$rpc['controller_service_name']</code>
+      <code>$service['controller_service_name']</code>
+    </MixedArrayAccess>
+    <MixedAssignment occurrences="6">
+      <code>$body</code>
+      <code>$body</code>
+      <code>$body</code>
+      <code>$body</code>
+      <code>$rpc</code>
+      <code>$service</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="12">
+      <code>addHeaders</code>
+      <code>delete</code>
+      <code>delete</code>
+      <code>getModel</code>
+      <code>getModel</code>
+      <code>getModuleName</code>
+      <code>getModuleName</code>
+      <code>getModuleName</code>
+      <code>patch</code>
+      <code>patch</code>
+      <code>setModuleName</code>
+      <code>setModuleName</code>
+    </MixedMethodCall>
+    <UndefinedInterfaceMethod occurrences="5">
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getHeaders</code>
+    </UndefinedInterfaceMethod>
+    <UndefinedThisPropertyAssignment occurrences="2">
+      <code>$this-&gt;resource</code>
+      <code>$this-&gt;rpcResource</code>
+    </UndefinedThisPropertyAssignment>
+  </file>
+  <file src="test/src/Admin/Model/DoctrineMetadataServiceResourceFactoryTest.php">
+    <MixedArgument occurrences="2">
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+    </MixedArgument>
+    <PossiblyUndefinedMethod occurrences="2">
+      <code>reveal</code>
+      <code>reveal</code>
+    </PossiblyUndefinedMethod>
+  </file>
+  <file src="test/src/Admin/Model/DoctrineRestServiceModelFactoryFactoryTest.php">
+    <MixedArgument occurrences="4">
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>ConfigResourceFactory::class</code>
+      <code>ConfigResourceFactory::class</code>
+    </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>$dependency</code>
+    </MixedArgumentTypeCoercion>
+    <MixedAssignment occurrences="1">
+      <code>$presence</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="9">
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+    </MixedMethodCall>
+    <PossiblyUndefinedMethod occurrences="11">
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>reveal</code>
+      <code>reveal</code>
+    </PossiblyUndefinedMethod>
+    <UndefinedClass occurrences="7">
+      <code>ConfigResourceFactory</code>
+      <code>ConfigResourceFactory</code>
+      <code>ConfigResourceFactory</code>
+      <code>ConfigResourceFactory</code>
+      <code>ConfigResourceFactory</code>
+      <code>ConfigResourceFactory</code>
+      <code>ConfigResourceFactory</code>
+    </UndefinedClass>
+  </file>
+  <file src="test/src/Admin/Model/DoctrineRestServiceResourceFactoryTest.php">
+    <InvalidReturnStatement occurrences="1"/>
+    <InvalidReturnType occurrences="1"/>
+    <MixedArgument occurrences="2">
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+    </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>$dependency</code>
+    </MixedArgumentTypeCoercion>
+    <MixedAssignment occurrences="1">
+      <code>$presence</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="7">
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+    </MixedMethodCall>
+    <PossiblyUndefinedMethod occurrences="9">
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>reveal</code>
+      <code>reveal</code>
+    </PossiblyUndefinedMethod>
+  </file>
+  <file src="test/src/Admin/Model/DoctrineRestServiceResourceTest.php">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>'Db\Entity\Artist'</code>
+    </ArgumentTypeCoercion>
+    <MissingFile occurrences="1">
+      <code>include __DIR__ . '/../../../../../config/application.config.php'</code>
+    </MissingFile>
+    <MixedArgument occurrences="4">
+      <code>$artist</code>
+      <code>$controllerServiceName</code>
+      <code>$em</code>
+      <code>include __DIR__ . '/../../../../../config/application.config.php'</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="2">
+      <code>$artist</code>
+      <code>$em</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="7">
+      <code>addHeaders</code>
+      <code>create</code>
+      <code>delete</code>
+      <code>getId</code>
+      <code>setCreatedAt</code>
+      <code>setModuleName</code>
+      <code>setName</code>
+    </MixedMethodCall>
+    <UndefinedClass occurrences="2">
+      <code>'Db\Entity\Artist'</code>
+      <code>Artist</code>
+    </UndefinedClass>
+    <UndefinedInterfaceMethod occurrences="2">
+      <code>getHeaders</code>
+      <code>setMethod</code>
+    </UndefinedInterfaceMethod>
+    <UndefinedThisPropertyAssignment occurrences="1">
+      <code>$this-&gt;resource</code>
+    </UndefinedThisPropertyAssignment>
+  </file>
+  <file src="test/src/Admin/Model/DoctrineRpcServiceModelFactoryFactoryTest.php">
+    <MixedArgument occurrences="4">
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>ConfigResourceFactory::class</code>
+      <code>ConfigResourceFactory::class</code>
+    </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>$dependency</code>
+    </MixedArgumentTypeCoercion>
+    <MixedAssignment occurrences="1">
+      <code>$presence</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="9">
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+    </MixedMethodCall>
+    <PossiblyUndefinedMethod occurrences="11">
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>reveal</code>
+      <code>reveal</code>
+    </PossiblyUndefinedMethod>
+    <UndefinedClass occurrences="7">
+      <code>ConfigResourceFactory</code>
+      <code>ConfigResourceFactory</code>
+      <code>ConfigResourceFactory</code>
+      <code>ConfigResourceFactory</code>
+      <code>ConfigResourceFactory</code>
+      <code>ConfigResourceFactory</code>
+      <code>ConfigResourceFactory</code>
+    </UndefinedClass>
+  </file>
+  <file src="test/src/Admin/Model/DoctrineRpcServiceResourceFactoryTest.php">
+    <MixedArgument occurrences="2">
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+    </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>$dependency</code>
+    </MixedArgumentTypeCoercion>
+    <MixedAssignment occurrences="1">
+      <code>$presence</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="9">
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+    </MixedMethodCall>
+    <PossiblyUndefinedMethod occurrences="11">
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>reveal</code>
+      <code>reveal</code>
+    </PossiblyUndefinedMethod>
+  </file>
+  <file src="test/src/Server/Event/Listener/CollectionListenerTest.php">
+    <MixedArgument occurrences="3">
+      <code>Artist::class</code>
+      <code>Artist::class</code>
+      <code>Artist::class</code>
+    </MixedArgument>
+    <MixedMethodCall occurrences="8">
+      <code>method</code>
+      <code>method</code>
+      <code>method</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>with</code>
+      <code>with</code>
+      <code>with</code>
+    </MixedMethodCall>
+    <PossiblyInvalidArgument occurrences="2">
+      <code>$entityFactory</code>
+      <code>$om</code>
+    </PossiblyInvalidArgument>
+    <UndefinedClass occurrences="8">
+      <code>Artist</code>
+      <code>Artist</code>
+      <code>Artist</code>
+      <code>Artist</code>
+      <code>Artist</code>
+      <code>Artist</code>
+      <code>Artist</code>
+      <code>Artist</code>
+    </UndefinedClass>
+    <UndefinedDocblockClass occurrences="5">
+      <code>$entityFactory</code>
+      <code>$entityFactory</code>
+      <code>$om</code>
+      <code>$om</code>
+      <code>$om</code>
+    </UndefinedDocblockClass>
+    <UndefinedInterfaceMethod occurrences="3">
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="test/src/Server/ODM/CRUD/CRUDTest.php">
+    <MissingClosureParamType occurrences="1">
+      <code>$class</code>
+    </MissingClosureParamType>
+    <MixedArgument occurrences="31">
+      <code>$body['_embedded']['meta']</code>
+      <code>$body['_embedded']['meta']</code>
+      <code>$config</code>
+      <code>$config['connectionString']</code>
+      <code>$meta</code>
+      <code>$this-&gt;getResponse()-&gt;getBody()</code>
+      <code>$this-&gt;getResponse()-&gt;getBody()</code>
+      <code>$this-&gt;getResponse()-&gt;getBody()</code>
+      <code>$this-&gt;getResponse()-&gt;getBody()</code>
+      <code>$this-&gt;getResponse()-&gt;getBody()</code>
+      <code>$this-&gt;getResponse()-&gt;getBody()</code>
+      <code>$this-&gt;getResponse()-&gt;getBody()</code>
+      <code>$this-&gt;getResponse()-&gt;getBody()</code>
+      <code>$this-&gt;getResponse()-&gt;getBody()</code>
+      <code>$this-&gt;getResponse()-&gt;getBody()</code>
+      <code>$this-&gt;getResponse()-&gt;getBody()</code>
+      <code>$this-&gt;getResponse()-&gt;getBody()</code>
+      <code>$this-&gt;getResponse()-&gt;getBody()</code>
+      <code>DoctrineResource::class</code>
+      <code>DoctrineResource::class</code>
+      <code>DoctrineResource::class</code>
+      <code>DoctrineResource::class</code>
+      <code>DoctrineResource::class</code>
+      <code>DoctrineResource::class</code>
+      <code>EventCatcher::class</code>
+      <code>Meta::class</code>
+      <code>Meta::class</code>
+      <code>Meta::class</code>
+      <code>Meta::class</code>
+      <code>Meta::class</code>
+      <code>Meta::class</code>
+    </MixedArgument>
+    <MixedArrayAccess occurrences="23">
+      <code>$body['_embedded']</code>
+      <code>$body['_embedded']</code>
+      <code>$body['_embedded']</code>
+      <code>$body['_embedded']</code>
+      <code>$body['detail']</code>
+      <code>$body['detail']</code>
+      <code>$body['detail']</code>
+      <code>$body['detail']</code>
+      <code>$body['detail']</code>
+      <code>$body['detail']</code>
+      <code>$body['id']</code>
+      <code>$body['name']</code>
+      <code>$body['name']</code>
+      <code>$body['name']</code>
+      <code>$body['name']</code>
+      <code>$body['name']</code>
+      <code>$body['total_items']</code>
+      <code>$body['total_items']</code>
+      <code>$config['api-tools']</code>
+      <code>$config['api-tools']</code>
+      <code>$config['connectionString']</code>
+      <code>$config['dbname']</code>
+      <code>$config['doctrine']</code>
+    </MixedArrayAccess>
+    <MixedArrayAssignment occurrences="2">
+      <code>$config['api-tools']</code>
+      <code>$resourceConfig['entity_factory']</code>
+    </MixedArrayAssignment>
+    <MixedAssignment occurrences="25">
+      <code>$body</code>
+      <code>$body</code>
+      <code>$body</code>
+      <code>$body</code>
+      <code>$body</code>
+      <code>$body</code>
+      <code>$body</code>
+      <code>$body</code>
+      <code>$body</code>
+      <code>$body</code>
+      <code>$body</code>
+      <code>$body</code>
+      <code>$body</code>
+      <code>$collection</code>
+      <code>$config</code>
+      <code>$config</code>
+      <code>$config</code>
+      <code>$config['api-tools']['doctrine-connected'][$resourceName]</code>
+      <code>$db</code>
+      <code>$eventCatcher</code>
+      <code>$id</code>
+      <code>$id</code>
+      <code>$meta</code>
+      <code>$resourceConfig</code>
+      <code>$this-&gt;dm</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="1">
+      <code>Meta</code>
+    </MixedInferredReturnType>
+    <MixedMethodCall occurrences="29">
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaders</code>
+      <code>addHeaders</code>
+      <code>addHeaders</code>
+      <code>addHeaders</code>
+      <code>format</code>
+      <code>getCaughtEvents</code>
+      <code>getCreatedAt</code>
+      <code>getId</code>
+      <code>getName</code>
+      <code>getName</code>
+      <code>method</code>
+      <code>new $class()</code>
+      <code>remove</code>
+      <code>setCreatedAt</code>
+      <code>setName</code>
+      <code>willReturnCallback</code>
+      <code>with</code>
+    </MixedMethodCall>
+    <MixedOperand occurrences="2">
+      <code>$id</code>
+      <code>$id</code>
+    </MixedOperand>
+    <MixedPropertyFetch occurrences="1">
+      <code>$db-&gt;meta</code>
+    </MixedPropertyFetch>
+    <MixedReturnStatement occurrences="1">
+      <code>$meta</code>
+    </MixedReturnStatement>
+    <PossiblyNullReference occurrences="10">
+      <code>attach</code>
+      <code>attach</code>
+      <code>attach</code>
+      <code>attach</code>
+      <code>attach</code>
+      <code>attach</code>
+      <code>getCreatedAt</code>
+      <code>getId</code>
+      <code>getName</code>
+      <code>getName</code>
+    </PossiblyNullReference>
+    <UndefinedClass occurrences="16">
+      <code>DoctrineResource</code>
+      <code>DoctrineResource</code>
+      <code>DoctrineResource</code>
+      <code>DoctrineResource</code>
+      <code>DoctrineResource</code>
+      <code>DoctrineResource</code>
+      <code>EventCatcher</code>
+      <code>Meta</code>
+      <code>Meta</code>
+      <code>Meta</code>
+      <code>Meta</code>
+      <code>Meta</code>
+      <code>Meta</code>
+      <code>Meta</code>
+      <code>Meta</code>
+      <code>Meta</code>
+    </UndefinedClass>
+    <UndefinedDocblockClass occurrences="20">
+      <code>$entityFactoryMock</code>
+      <code>$entityFactoryMock</code>
+      <code>$meta</code>
+      <code>$meta</code>
+      <code>$meta</code>
+      <code>$meta</code>
+      <code>$meta</code>
+      <code>$meta</code>
+      <code>$meta</code>
+      <code>$meta</code>
+      <code>$meta</code>
+      <code>$meta</code>
+      <code>$meta</code>
+      <code>$meta</code>
+      <code>$meta</code>
+      <code>$meta</code>
+      <code>$meta</code>
+      <code>$meta1</code>
+      <code>$meta2</code>
+      <code>Meta</code>
+    </UndefinedDocblockClass>
+    <UndefinedInterfaceMethod occurrences="42">
+      <code>expects</code>
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getConfig</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>setMethod</code>
+      <code>setMethod</code>
+      <code>setMethod</code>
+      <code>setMethod</code>
+      <code>setMethod</code>
+      <code>setMethod</code>
+      <code>setMethod</code>
+      <code>setMethod</code>
+      <code>setMethod</code>
+      <code>setMethod</code>
+      <code>setMethod</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="test/src/Server/ORM/CRUD/CRUDTest.php">
+    <MissingClosureParamType occurrences="1">
+      <code>$class</code>
+    </MissingClosureParamType>
+    <MixedArgument occurrences="50">
+      <code>$album-&gt;getId()</code>
+      <code>$artist</code>
+      <code>$artist-&gt;getId()</code>
+      <code>$body['_embedded']['artist']</code>
+      <code>$body['_embedded']['artist']</code>
+      <code>$config</code>
+      <code>$event</code>
+      <code>$eventCatcher-&gt;getCaughtEvents()</code>
+      <code>$filter($mapping['fieldName'])</code>
+      <code>$product</code>
+      <code>$product-&gt;getId()</code>
+      <code>$this-&gt;getResponse()-&gt;getBody()</code>
+      <code>$this-&gt;getResponse()-&gt;getBody()</code>
+      <code>$this-&gt;getResponse()-&gt;getBody()</code>
+      <code>$this-&gt;getResponse()-&gt;getBody()</code>
+      <code>$this-&gt;getResponse()-&gt;getBody()</code>
+      <code>$this-&gt;getResponse()-&gt;getBody()</code>
+      <code>$this-&gt;getResponse()-&gt;getBody()</code>
+      <code>$this-&gt;getResponse()-&gt;getBody()</code>
+      <code>$this-&gt;getResponse()-&gt;getBody()</code>
+      <code>$this-&gt;getResponse()-&gt;getBody()</code>
+      <code>$this-&gt;getResponse()-&gt;getBody()</code>
+      <code>$this-&gt;getResponse()-&gt;getBody()</code>
+      <code>$this-&gt;getResponse()-&gt;getBody()</code>
+      <code>$this-&gt;getResponse()-&gt;getBody()</code>
+      <code>$this-&gt;getResponse()-&gt;getBody()</code>
+      <code>$this-&gt;getResponse()-&gt;getBody()</code>
+      <code>$this-&gt;getResponse()-&gt;getBody()</code>
+      <code>$this-&gt;getResponse()-&gt;getBody()</code>
+      <code>$this-&gt;getResponse()-&gt;getBody()</code>
+      <code>$this-&gt;getResponse()-&gt;getBody()</code>
+      <code>$this-&gt;getResponse()-&gt;getBody()</code>
+      <code>$this-&gt;getResponse()-&gt;getBody()</code>
+      <code>Artist::class</code>
+      <code>Artist::class</code>
+      <code>Artist::class</code>
+      <code>Artist::class</code>
+      <code>Artist::class</code>
+      <code>Artist::class</code>
+      <code>Artist::class</code>
+      <code>Artist::class</code>
+      <code>Artist::class</code>
+      <code>Artist::class</code>
+      <code>Artist::class</code>
+      <code>Artist::class</code>
+      <code>Artist::class</code>
+      <code>DoctrineResource::class</code>
+      <code>DoctrineResource::class</code>
+      <code>EventCatcher::class</code>
+      <code>EventCatcher::class</code>
+    </MixedArgument>
+    <MixedArrayAccess occurrences="38">
+      <code>$body['_embedded']</code>
+      <code>$body['_embedded']</code>
+      <code>$body['_embedded']</code>
+      <code>$body['_embedded']</code>
+      <code>$body['_embedded']</code>
+      <code>$body['_embedded']</code>
+      <code>$body['_embedded']</code>
+      <code>$body['_embedded']</code>
+      <code>$body['detail']</code>
+      <code>$body['detail']</code>
+      <code>$body['detail']</code>
+      <code>$body['detail']</code>
+      <code>$body['detail']</code>
+      <code>$body['detail']</code>
+      <code>$body['detail']</code>
+      <code>$body['detail']</code>
+      <code>$body['id']</code>
+      <code>$body['id']</code>
+      <code>$body['id']</code>
+      <code>$body['name']</code>
+      <code>$body['name']</code>
+      <code>$body['name']</code>
+      <code>$body['name']</code>
+      <code>$body['name']</code>
+      <code>$body['name']</code>
+      <code>$body['name']</code>
+      <code>$body['total_items']</code>
+      <code>$body['total_items']</code>
+      <code>$body['version']</code>
+      <code>$config['api-tools']</code>
+      <code>$config['api-tools']</code>
+      <code>$config['api-tools']</code>
+      <code>$mapping['fieldName']</code>
+      <code>$mapping['fieldName']</code>
+      <code>$mapping['fieldName']</code>
+      <code>$mapping['sourceEntity']</code>
+      <code>$mapping['targetEntity']</code>
+      <code>$mapping['type']</code>
+    </MixedArrayAccess>
+    <MixedArrayAssignment occurrences="3">
+      <code>$config['api-tools']</code>
+      <code>$config['api-tools']</code>
+      <code>$resourceConfig['entity_factory']</code>
+    </MixedArrayAssignment>
+    <MixedArrayOffset occurrences="1">
+      <code>$config['api-tools']['doctrine-connected'][ArtistResource::class]</code>
+    </MixedArrayOffset>
+    <MixedAssignment occurrences="35">
+      <code>$artist</code>
+      <code>$body</code>
+      <code>$body</code>
+      <code>$body</code>
+      <code>$body</code>
+      <code>$body</code>
+      <code>$body</code>
+      <code>$body</code>
+      <code>$body</code>
+      <code>$body</code>
+      <code>$body</code>
+      <code>$body</code>
+      <code>$body</code>
+      <code>$body</code>
+      <code>$body</code>
+      <code>$body</code>
+      <code>$body</code>
+      <code>$body</code>
+      <code>$body</code>
+      <code>$body</code>
+      <code>$body</code>
+      <code>$body</code>
+      <code>$body</code>
+      <code>$config</code>
+      <code>$config</code>
+      <code>$config['api-tools']['doctrine-connected'][$resourceName]</code>
+      <code>$event</code>
+      <code>$eventCatcher</code>
+      <code>$eventCatcher</code>
+      <code>$id</code>
+      <code>$id</code>
+      <code>$id</code>
+      <code>$mapping</code>
+      <code>$product</code>
+      <code>$resourceConfig</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="3">
+      <code>Album</code>
+      <code>Artist</code>
+      <code>Product</code>
+    </MixedInferredReturnType>
+    <MixedMethodCall occurrences="45">
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaders</code>
+      <code>addHeaders</code>
+      <code>addHeaders</code>
+      <code>addHeaders</code>
+      <code>addHeaders</code>
+      <code>addHeaders</code>
+      <code>addHeaders</code>
+      <code>addHeaders</code>
+      <code>format</code>
+      <code>getCaughtEvents</code>
+      <code>getCaughtEvents</code>
+      <code>getCreatedAt</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getName</code>
+      <code>getName</code>
+      <code>method</code>
+      <code>new $class()</code>
+      <code>setCreatedAt</code>
+      <code>setName</code>
+      <code>willReturnCallback</code>
+      <code>with</code>
+    </MixedMethodCall>
+    <MixedOperand occurrences="4">
+      <code>$id</code>
+      <code>$id</code>
+      <code>$id</code>
+      <code>$mapping['fieldName']</code>
+    </MixedOperand>
+    <MixedReturnStatement occurrences="2">
+      <code>$artist</code>
+      <code>$product</code>
+    </MixedReturnStatement>
+    <NoInterfaceProperties occurrences="1">
+      <code>$entityMetadata-&gt;associationMappings</code>
+    </NoInterfaceProperties>
+    <PossiblyNullReference occurrences="9">
+      <code>attach</code>
+      <code>attach</code>
+      <code>getCreatedAt</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getName</code>
+      <code>getName</code>
+    </PossiblyNullReference>
+    <UndefinedClass occurrences="26">
+      <code>?Artist</code>
+      <code>Album</code>
+      <code>Artist</code>
+      <code>Artist</code>
+      <code>Artist</code>
+      <code>Artist</code>
+      <code>Artist</code>
+      <code>Artist</code>
+      <code>Artist</code>
+      <code>Artist</code>
+      <code>Artist</code>
+      <code>Artist</code>
+      <code>Artist</code>
+      <code>Artist</code>
+      <code>Artist</code>
+      <code>Artist</code>
+      <code>Artist</code>
+      <code>Artist</code>
+      <code>Artist</code>
+      <code>ArtistResource</code>
+      <code>DoctrineResource</code>
+      <code>DoctrineResource</code>
+      <code>EventCatcher</code>
+      <code>EventCatcher</code>
+      <code>Product</code>
+      <code>Product</code>
+    </UndefinedClass>
+    <UndefinedDocblockClass occurrences="54">
+      <code>$album</code>
+      <code>$album</code>
+      <code>$artist</code>
+      <code>$artist</code>
+      <code>$artist</code>
+      <code>$artist</code>
+      <code>$artist</code>
+      <code>$artist</code>
+      <code>$artist</code>
+      <code>$artist</code>
+      <code>$artist</code>
+      <code>$artist</code>
+      <code>$artist</code>
+      <code>$artist</code>
+      <code>$artist</code>
+      <code>$artist</code>
+      <code>$artist</code>
+      <code>$artist</code>
+      <code>$artist</code>
+      <code>$artist</code>
+      <code>$artist</code>
+      <code>$artist</code>
+      <code>$artist</code>
+      <code>$artist1</code>
+      <code>$artist1</code>
+      <code>$artist1</code>
+      <code>$artist1</code>
+      <code>$artist1</code>
+      <code>$artist1</code>
+      <code>$artist1</code>
+      <code>$artist2</code>
+      <code>$artist2</code>
+      <code>$artist2</code>
+      <code>$artist2</code>
+      <code>$artist2</code>
+      <code>$artist2</code>
+      <code>$artist2</code>
+      <code>$artist3</code>
+      <code>$artist3</code>
+      <code>$artist3</code>
+      <code>$artist3</code>
+      <code>$artist3</code>
+      <code>$artist3</code>
+      <code>$entityFactoryMock</code>
+      <code>$entityFactoryMock</code>
+      <code>$product</code>
+      <code>$product</code>
+      <code>$product</code>
+      <code>$product</code>
+      <code>$product</code>
+      <code>$product</code>
+      <code>Album</code>
+      <code>Artist</code>
+      <code>Product</code>
+    </UndefinedDocblockClass>
+    <UndefinedInterfaceMethod occurrences="77">
+      <code>expects</code>
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+      <code>setAllowOverride</code>
+      <code>setAllowOverride</code>
+      <code>setMethod</code>
+      <code>setMethod</code>
+      <code>setMethod</code>
+      <code>setMethod</code>
+      <code>setMethod</code>
+      <code>setMethod</code>
+      <code>setMethod</code>
+      <code>setMethod</code>
+      <code>setMethod</code>
+      <code>setMethod</code>
+      <code>setMethod</code>
+      <code>setMethod</code>
+      <code>setMethod</code>
+      <code>setMethod</code>
+      <code>setMethod</code>
+      <code>setMethod</code>
+      <code>setMethod</code>
+      <code>setMethod</code>
+      <code>setMethod</code>
+      <code>setMethod</code>
+      <code>setMethod</code>
+      <code>setService</code>
+      <code>setService</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="test/src/Server/Validator/NoObjectExistsFactoryTest.php">
+    <MixedArgument occurrences="3">
+      <code>$validatorsConfig</code>
+      <code>NoObjectExists::class</code>
+      <code>NoObjectExists::class</code>
+    </MixedArgument>
+    <MixedArrayAccess occurrences="1">
+      <code>$config['validators']</code>
+    </MixedArrayAccess>
+    <MixedAssignment occurrences="2">
+      <code>$config</code>
+      <code>$validatorsConfig</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="1">
+      <code>willReturn</code>
+    </MixedMethodCall>
+    <PossiblyInvalidMethodCall occurrences="1">
+      <code>willReturn</code>
+    </PossiblyInvalidMethodCall>
+    <PossiblyUndefinedMethod occurrences="2">
+      <code>reveal</code>
+      <code>reveal</code>
+    </PossiblyUndefinedMethod>
+    <UndefinedClass occurrences="2">
+      <code>NoObjectExists</code>
+      <code>NoObjectExists</code>
+    </UndefinedClass>
+  </file>
+  <file src="test/src/Server/Validator/ObjectExistsFactoryTest.php">
+    <MixedArgument occurrences="3">
+      <code>$validatorsConfig</code>
+      <code>ObjectExists::class</code>
+      <code>ObjectExists::class</code>
+    </MixedArgument>
+    <MixedArrayAccess occurrences="1">
+      <code>$config['validators']</code>
+    </MixedArrayAccess>
+    <MixedAssignment occurrences="2">
+      <code>$config</code>
+      <code>$validatorsConfig</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="1">
+      <code>willReturn</code>
+    </MixedMethodCall>
+    <PossiblyInvalidMethodCall occurrences="1">
+      <code>willReturn</code>
+    </PossiblyInvalidMethodCall>
+    <PossiblyUndefinedMethod occurrences="2">
+      <code>reveal</code>
+      <code>reveal</code>
+    </PossiblyUndefinedMethod>
+    <UndefinedClass occurrences="2">
+      <code>ObjectExists</code>
+      <code>ObjectExists</code>
+    </UndefinedClass>
+  </file>
+  <file src="test/src/TestCase.php">
+    <LessSpecificReturnStatement occurrences="1">
+      <code>parent::setApplicationConfig($config)</code>
+    </LessSpecificReturnStatement>
+    <MixedArgument occurrences="1">
+      <code>$config['modules']</code>
+    </MixedArgument>
+    <MixedArrayAccess occurrences="1">
+      <code>$config['module_listener_options']['module_paths']</code>
+    </MixedArrayAccess>
+    <MixedAssignment occurrences="2">
+      <code>$file</code>
+      <code>$this-&gt;enabledModules</code>
+    </MixedAssignment>
+    <MixedOperand occurrences="1">
+      <code>$file</code>
+    </MixedOperand>
+    <MoreSpecificImplementedParamType occurrences="1">
+      <code>$config</code>
+    </MoreSpecificImplementedParamType>
+    <MoreSpecificReturnType occurrences="1">
+      <code>$this</code>
+    </MoreSpecificReturnType>
+    <ParamNameMismatch occurrences="1">
+      <code>$config</code>
+    </ParamNameMismatch>
+    <PossiblyNullReference occurrences="1">
+      <code>getNumberOfRequiredParameters</code>
+    </PossiblyNullReference>
+  </file>
+</files>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<psalm
+        totallyTyped="true"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="https://getpsalm.org/schema/config"
+        xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorBaseline="psalm-baseline.xml"
+>
+    <projectFiles>
+        <directory name="config"/>
+        <directory name="src"/>
+        <directory name="test"/>
+        <ignoreFiles>
+            <directory name=".github"/>
+            <directory name="vendor"/>
+        </ignoreFiles>
+    </projectFiles>
+
+    <issueHandlers>
+        <InternalMethod>
+            <errorLevel type="suppress">
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::method"/>
+            </errorLevel>
+            <errorLevel type="suppress">
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::willReturn"/>
+            </errorLevel>
+            <errorLevel type="suppress">
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::with"/>
+            </errorLevel>
+        </InternalMethod>
+    </issueHandlers>
+
+    <plugins>
+        <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
+    </plugins>
+</psalm>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -13,6 +13,8 @@
         <ignoreFiles>
             <directory name=".github"/>
             <directory name="vendor"/>
+            <directory name="test/assets"/>
+            <directory name="test/data"/>
         </ignoreFiles>
     </projectFiles>
 

--- a/src/Admin/Model/DoctrineRestServiceModel.php
+++ b/src/Admin/Model/DoctrineRestServiceModel.php
@@ -447,7 +447,7 @@ class DoctrineRestServiceModel implements EventManagerAwareInterface
     /**
      * Update an existing service
      *
-     * @return DoctrineRestServiceEntity
+     * @return DoctrineRestServiceEntity|false
      */
     public function updateService(DoctrineRestServiceEntity $update)
     {
@@ -477,7 +477,7 @@ class DoctrineRestServiceModel implements EventManagerAwareInterface
      * @todo Remove content-negotiation and/or HAL configuration?
      * @param string $controllerService
      * @param bool $recursive
-     * @return true
+     * @return ApiProblem|true
      */
     public function deleteService($controllerService, $recursive = false)
     {
@@ -495,7 +495,7 @@ class DoctrineRestServiceModel implements EventManagerAwareInterface
             Utility::recursiveDelete(dirname($reflection->getFileName()));
         }
         $this->deleteRoute($service);
-        $response = $this->deleteDoctrineRestConfig($service);
+        $this->deleteDoctrineRestConfig($service);
 
         if ($response instanceof ApiProblem) {
             return $response;
@@ -676,6 +676,7 @@ class DoctrineRestServiceModel implements EventManagerAwareInterface
      * @param string $controllerService
      * @param string $resourceClass
      * @param string $routeName
+     * @return void
      */
     public function createRestConfig(DoctrineRestServiceEntity $details, $controllerService, $resourceClass, $routeName)
     {
@@ -706,6 +707,7 @@ class DoctrineRestServiceModel implements EventManagerAwareInterface
      * controller service name
      *
      * @param string $controllerService
+     * @return void
      */
     public function createContentNegotiationConfig(DoctrineRestServiceEntity $details, $controllerService)
     {
@@ -732,12 +734,12 @@ class DoctrineRestServiceModel implements EventManagerAwareInterface
      * @param string $entityClass
      * @param string $collectionClass
      * @param string $routeName
+     * @return void
      */
     public function createDoctrineConfig(DoctrineRestServiceEntity $details, $entityClass, $collectionClass, $routeName)
     {
-        $entityValue        = $details->getArrayCopy();
-        $objectManager      = $this->getServiceManager()->get($details->objectManager);
-        $hydratorStrategies = [];
+        $details->getArrayCopy();
+        $this->getServiceManager()->get($details->objectManager);
 
         // The abstract_factories key is set to the value so these factories do not get duplicaed with each resource
         $config = [
@@ -760,6 +762,7 @@ class DoctrineRestServiceModel implements EventManagerAwareInterface
      * @param string $entityClass
      * @param string $collectionClass
      * @param string $routeName
+     * @return void
      * @throws CreationException
      */
     public function createDoctrineHydratorConfig(
@@ -771,7 +774,7 @@ class DoctrineRestServiceModel implements EventManagerAwareInterface
         $entityValue = $details->getArrayCopy();
 
         // Verify the object manager exists
-        $objectManager      = $this->getServiceManager()->get($details->objectManager);
+        $this->getServiceManager()->get($details->objectManager);
         $hydratorStrategies = $entityValue['strategies'] ?? [];
 
         foreach ($hydratorStrategies as $strategy) {
@@ -802,6 +805,7 @@ class DoctrineRestServiceModel implements EventManagerAwareInterface
      * @param string $entityClass
      * @param string $collectionClass
      * @param string $routeName
+     * @return void
      */
     public function createHalConfig(DoctrineRestServiceEntity $details, $entityClass, $collectionClass, $routeName)
     {
@@ -831,6 +835,8 @@ class DoctrineRestServiceModel implements EventManagerAwareInterface
 
     /**
      * Update the route for an existing service
+     *
+     * @return void
      */
     public function updateRoute(DoctrineRestServiceEntity $original, DoctrineRestServiceEntity $update)
     {
@@ -857,6 +863,8 @@ class DoctrineRestServiceModel implements EventManagerAwareInterface
 
     /**
      * Update REST configuration
+     *
+     * @return void
      */
     public function updateRestConfig(DoctrineRestServiceEntity $original, DoctrineRestServiceEntity $update)
     {
@@ -888,10 +896,11 @@ class DoctrineRestServiceModel implements EventManagerAwareInterface
 
     /**
      * Update Doctrine hydrator configuration
+     *
+     * @return void
      */
     public function updateDoctrineHydratorConfig(DoctrineRestServiceEntity $original, DoctrineRestServiceEntity $update)
     {
-        $patch = [];
         foreach ($this->doctrineHydratorOptions as $property => $configKey) {
             if ($update->$property === null) {
                 continue;
@@ -903,6 +912,8 @@ class DoctrineRestServiceModel implements EventManagerAwareInterface
 
     /**
      * Update the content negotiation configuration for the service
+     *
+     * @return void
      */
     public function updateContentNegotiationConfig(
         DoctrineRestServiceEntity $original,
@@ -931,6 +942,8 @@ class DoctrineRestServiceModel implements EventManagerAwareInterface
 
     /**
      * Update Doctrine configuration
+     *
+     * @return void
      */
     public function updateDoctrineConfig(DoctrineRestServiceEntity $original, DoctrineRestServiceEntity $update)
     {
@@ -945,6 +958,8 @@ class DoctrineRestServiceModel implements EventManagerAwareInterface
 
     /**
      * Delete the files which were automatically created
+     *
+     * @return void
      */
     public function deleteFiles(DoctrineRestServiceEntity $entity)
     {
@@ -962,6 +977,8 @@ class DoctrineRestServiceModel implements EventManagerAwareInterface
 
     /**
      * Delete the route associated with the given service
+     *
+     * @return void
      */
     public function deleteRoute(DoctrineRestServiceEntity $entity)
     {
@@ -981,13 +998,15 @@ class DoctrineRestServiceModel implements EventManagerAwareInterface
     /**
      * Delete the REST configuration associated with the given
      * service
+     *
+     * @return void
      */
     public function deleteDoctrineRestConfig(DoctrineRestServiceEntity $entity)
     {
         // Get hydrator name
-        $config             = $this->configResource->fetch(true);
-        $hydratorName       = $config['api-tools-hal']['metadata_map'][$entity->entityClass]['hydrator'];
-        $objectManagerClass = $config['doctrine-hydrator'][$hydratorName]['object_manager'];
+        $config       = $this->configResource->fetch(true);
+        $hydratorName = $config['api-tools-hal']['metadata_map'][$entity->entityClass]['hydrator'];
+        $config['doctrine-hydrator'][$hydratorName]['object_manager'];
 
         $key = ['doctrine-hydrator', $hydratorName];
         $this->configResource->deleteKey($key);
@@ -1129,6 +1148,7 @@ class DoctrineRestServiceModel implements EventManagerAwareInterface
      * Retrieve route information for a given service based on the configuration available
      *
      * @param array $config
+     * @return void
      */
     protected function getRouteInfo(DoctrineRestServiceEntity $metadata, array $config)
     {
@@ -1151,6 +1171,7 @@ class DoctrineRestServiceModel implements EventManagerAwareInterface
      *
      * @param string $controllerServiceName
      * @param array $config
+     * @return void
      */
     protected function mergeContentNegotiationConfig(
         $controllerServiceName,
@@ -1187,6 +1208,7 @@ class DoctrineRestServiceModel implements EventManagerAwareInterface
      *
      * @param string $controllerServiceName
      * @param array $config
+     * @return void
      */
     protected function mergeHalConfig($controllerServiceName, DoctrineRestServiceEntity $metadata, array $config)
     {

--- a/src/Admin/Model/DoctrineRestServiceResource.php
+++ b/src/Admin/Model/DoctrineRestServiceResource.php
@@ -7,6 +7,7 @@ namespace Laminas\ApiTools\Doctrine\Admin\Model;
 use Exception;
 use Laminas\ApiTools\Admin\Model\DocumentationModel;
 use Laminas\ApiTools\Admin\Model\InputFilterModel;
+use Laminas\ApiTools\Admin\Model\RestServiceModel;
 use Laminas\ApiTools\Admin\Model\RestServiceResource;
 use Laminas\ApiTools\ApiProblem\ApiProblem;
 
@@ -39,7 +40,7 @@ class DoctrineRestServiceResource extends RestServiceResource
 
     /**
      * @param string $type
-     * @return DoctrineRestServiceModel
+     * @return RestServiceModel
      */
     public function getModel($type = DoctrineRestServiceModelFactory::TYPE_DEFAULT)
     {

--- a/src/Admin/Model/DoctrineRpcServiceModel.php
+++ b/src/Admin/Model/DoctrineRpcServiceModel.php
@@ -107,7 +107,8 @@ class DoctrineRpcServiceModel
      * Fetch all services
      *
      * @param string $version
-     * @return DoctrineRpcServiceEntity[]
+     * @return (DoctrineRpcServiceEntity|false)[]
+     * @psalm-return list<DoctrineRpcServiceEntity|false>
      */
     public function fetchAll($version = null)
     {
@@ -164,7 +165,7 @@ class DoctrineRpcServiceModel
      * @param array $httpMethods
      * @param null|string $selector
      * @param array $options
-     * @return DoctrineRpcServiceEntity
+     * @return DoctrineRpcServiceEntity|false
      */
     public function createService($serviceName, $route, $httpMethods, $selector, $options)
     {
@@ -208,10 +209,12 @@ class DoctrineRpcServiceModel
 
     /**
      * Delete the files which were automatically created
+     *
+     * @return void
      */
     public function deleteFiles(DoctrineRpcServiceEntity $entity)
     {
-        $config = $this->configResource->fetch(true);
+        $this->configResource->fetch(true);
 
         $reflector = new ReflectionClass($entity->controllerClass);
         unlink($reflector->getFileName());
@@ -421,7 +424,7 @@ class DoctrineRpcServiceModel
      *
      * @param string $controllerService
      * @param string $routeMatch
-     * @return true
+     * @return bool
      */
     public function updateRoute($controllerService, $routeMatch)
     {
@@ -500,6 +503,7 @@ class DoctrineRpcServiceModel
      * Removes the route configuration for a named route
      *
      * @param string $routeName
+     * @return void
      */
     public function deleteRouteConfig($routeName)
     {
@@ -516,6 +520,7 @@ class DoctrineRpcServiceModel
      * Delete the RPC configuration for a named RPC service
      *
      * @param string $serviceName
+     * @return void
      */
     public function deleteDoctrineRpcConfig($serviceName)
     {
@@ -551,6 +556,7 @@ class DoctrineRpcServiceModel
      * service
      *
      * @param string $serviceName
+     * @return void
      */
     public function deleteContentNegotiationConfig($serviceName)
     {

--- a/src/Admin/Model/DoctrineRpcServiceResource.php
+++ b/src/Admin/Model/DoctrineRpcServiceResource.php
@@ -7,6 +7,7 @@ namespace Laminas\ApiTools\Doctrine\Admin\Model;
 use Exception;
 use Laminas\ApiTools\Admin\Model\DocumentationModel;
 use Laminas\ApiTools\Admin\Model\InputFilterModel;
+use Laminas\ApiTools\Admin\Model\RpcServiceModel;
 use Laminas\ApiTools\Admin\Model\RpcServiceResource;
 use Laminas\ApiTools\ApiProblem\ApiProblem;
 use Laminas\ApiTools\Rest\Exception\CreationException;
@@ -42,7 +43,7 @@ class DoctrineRpcServiceResource extends RpcServiceResource
     }
 
     /**
-     * @return DoctrineRpcServiceModel
+     * @return RpcServiceModel
      */
     public function getModel()
     {

--- a/src/Server/Event/Listener/CollectionListener.php
+++ b/src/Server/Event/Listener/CollectionListener.php
@@ -16,6 +16,7 @@ use Laminas\EventManager\ListenerAggregateInterface;
 use Laminas\Hydrator\HydratorInterface;
 use Laminas\InputFilter\CollectionInputFilter;
 use Laminas\InputFilter\InputFilterInterface;
+use Laminas\InputFilter\InputInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use Laminas\Stdlib\ArrayObject;
 use Phpro\DoctrineHydrationModule\Service\DoctrineHydratorFactory;
@@ -280,7 +281,7 @@ class CollectionListener implements ListenerAggregateInterface
 
     /**
      * @param string $association
-     * @return InputFilterInterface
+     * @return InputFilterInterface|InputInterface
      */
     protected function getAssociatedEntityInputFilter($association, InputFilterInterface $inputFilter)
     {

--- a/src/Server/Module.php
+++ b/src/Server/Module.php
@@ -22,6 +22,8 @@ class Module
 
     /**
      * Module init
+     *
+     * @return void
      */
     public function init(ModuleManager $moduleManager)
     {

--- a/src/Server/Paginator/Adapter/DoctrineOdmAdapter.php
+++ b/src/Server/Paginator/Adapter/DoctrineOdmAdapter.php
@@ -22,6 +22,7 @@ class DoctrineOdmAdapter implements AdapterInterface
 
     /**
      * @param Builder $queryBuilder
+     * @return void
      */
     public function setQueryBuilder($queryBuilder)
     {

--- a/src/Server/Query/CreateFilter/AbstractCreateFilter.php
+++ b/src/Server/Query/CreateFilter/AbstractCreateFilter.php
@@ -22,6 +22,8 @@ abstract class AbstractCreateFilter implements ObjectManagerAwareInterface, Quer
 
     /**
      * Set the object manager
+     *
+     * @return void
      */
     public function setObjectManager(ObjectManager $objectManager)
     {

--- a/src/Server/Query/Provider/AbstractQueryProvider.php
+++ b/src/Server/Query/Provider/AbstractQueryProvider.php
@@ -19,6 +19,8 @@ abstract class AbstractQueryProvider implements ObjectManagerAwareInterface, Que
 
     /**
      * Set the object manager
+     *
+     * @return void
      */
     public function setObjectManager(ObjectManager $objectManager)
     {

--- a/src/Server/Resource/DoctrineResource.php
+++ b/src/Server/Resource/DoctrineResource.php
@@ -160,7 +160,7 @@ class DoctrineResource extends AbstractResourceListener implements
     /**
      * Set the object manager
      *
-     * @param ObjectManager|EntityManagerInterface $objectManager
+     * @return void
      */
     public function setObjectManager(ObjectManager $objectManager)
     {
@@ -179,6 +179,7 @@ class DoctrineResource extends AbstractResourceListener implements
 
     /**
      * @param array|QueryProviderInterface[] $queryProviders
+     * @return void
      * @throws InvalidArgumentException If parameter is not an array or \Traversable object.
      */
     public function setQueryProviders($queryProviders)
@@ -197,7 +198,7 @@ class DoctrineResource extends AbstractResourceListener implements
     }
 
     /**
-     * @return array|QueryProviderInterface[]
+     * @return QueryProviderInterface|array
      */
     public function getQueryProviders()
     {
@@ -539,7 +540,7 @@ class DoctrineResource extends AbstractResourceListener implements
         }
 
         // Add event to set extra HAL data
-        $entityClass = $this->getEntityClass();
+        $this->getEntityClass();
 
         $this->getSharedEventManager()->attach(
             RestController::class,

--- a/src/Server/Validator/NoObjectExistsFactory.php
+++ b/src/Server/Validator/NoObjectExistsFactory.php
@@ -59,6 +59,7 @@ class NoObjectExistsFactory implements FactoryInterface
      * Allow injecting options at build time; required for v2 compatibility.
      *
      * @param array $options
+     * @return void
      */
     public function setCreationOptions(array $options)
     {

--- a/src/Server/Validator/ObjectExistsFactory.php
+++ b/src/Server/Validator/ObjectExistsFactory.php
@@ -59,6 +59,7 @@ class ObjectExistsFactory implements FactoryInterface
      * Allow injecting options at build time; required for v2 compatibility.
      *
      * @param array $options
+     * @return void
      */
     public function setCreationOptions(array $options)
     {

--- a/test/assets/module/LaminasTestApiToolsDb/src/LaminasTestApiToolsDb/Entity/Album.php
+++ b/test/assets/module/LaminasTestApiToolsDb/src/LaminasTestApiToolsDb/Entity/Album.php
@@ -23,7 +23,10 @@ class Album
         return $this->name;
     }
 
-    public function setName($value)
+    /**
+     * @return static
+     */
+    public function setName(string $value): self
     {
         $this->name = $value;
 
@@ -37,7 +40,10 @@ class Album
         return $this->createdAt;
     }
 
-    public function setCreatedAt(DateTime $value)
+    /**
+     * @return static
+     */
+    public function setCreatedAt(DateTime $value): self
     {
         $this->createdAt = $value;
 
@@ -51,7 +57,10 @@ class Album
         return $this->artist;
     }
 
-    public function setArtist($value)
+    /**
+     * @return static
+     */
+    public function setArtist(Artist $value): self
     {
         $this->artist = $value;
 

--- a/test/assets/module/LaminasTestApiToolsDb/src/LaminasTestApiToolsDb/Entity/Artist.php
+++ b/test/assets/module/LaminasTestApiToolsDb/src/LaminasTestApiToolsDb/Entity/Artist.php
@@ -33,7 +33,10 @@ class Artist
         return $this->name;
     }
 
-    public function setName($value)
+    /**
+     * @return static
+     */
+    public function setName(string $value): self
     {
         $this->name = $value;
 
@@ -47,7 +50,10 @@ class Artist
         return $this->createdAt;
     }
 
-    public function setCreatedAt(DateTime $value)
+    /**
+     * @return static
+     */
+    public function setCreatedAt(DateTime $value): self
     {
         $this->createdAt = $value;
 
@@ -88,9 +94,12 @@ class Artist
      * Remove album
      *
      * @param Album $album
+     *
      * @throws Exception
+     *
+     * @return void
      */
-    public function removeAlbum($album)
+    public function removeAlbum($album): void
     {
         if ($album instanceof Album) {
             $this->album[] = $album;

--- a/test/assets/module/LaminasTestApiToolsDb/src/LaminasTestApiToolsDb/Entity/Product.php
+++ b/test/assets/module/LaminasTestApiToolsDb/src/LaminasTestApiToolsDb/Entity/Product.php
@@ -20,7 +20,7 @@ class Product
         return $this->version;
     }
 
-    public function setVersion($version)
+    public function setVersion($version): void
     {
         $this->version = $version;
     }

--- a/test/assets/module/LaminasTestApiToolsDb/src/LaminasTestApiToolsDb/EventListener/ArtistAggregateListener.php
+++ b/test/assets/module/LaminasTestApiToolsDb/src/LaminasTestApiToolsDb/EventListener/ArtistAggregateListener.php
@@ -20,9 +20,9 @@ class ArtistAggregateListener implements ListenerAggregateInterface
         );
     }
 
-    public function createPost(DoctrineResourceEvent $event)
+    public function createPost(DoctrineResourceEvent $event): void
     {
-        $objectManager = $event->getObjectManager();
+        $event->getObjectManager();
 
         $event->getEntity();
         $event->getData();

--- a/test/assets/module/LaminasTestApiToolsDb/src/LaminasTestApiToolsDb/Module.php
+++ b/test/assets/module/LaminasTestApiToolsDb/src/LaminasTestApiToolsDb/Module.php
@@ -14,7 +14,11 @@ class Module implements ApiToolsProviderInterface
         return include __DIR__ . '/../../config/module.config.php';
     }
 
-    public function getAutoloaderConfig()
+    /**
+     * @return string[][][]
+     * @psalm-return array<string, array<string, array<string, string>>>
+     */
+    public function getAutoloaderConfig(): array
     {
         return [
             StandardAutoloader::class => [

--- a/test/assets/module/LaminasTestApiToolsDbApi/src/LaminasTestApiToolsDbApi/Module.php
+++ b/test/assets/module/LaminasTestApiToolsDbApi/src/LaminasTestApiToolsDbApi/Module.php
@@ -9,12 +9,21 @@ use Laminas\Loader\StandardAutoloader;
 
 class Module implements ApiToolsProviderInterface
 {
-    public function getConfig()
+    /**
+     * @return array
+     *
+     * @psalm-return array<empty, empty>
+     */
+    public function getConfig(): array
     {
         return include __DIR__ . '/../../config/module.config.php';
     }
 
-    public function getAutoloaderConfig()
+    /**
+     * @return string[][][]
+     * @psalm-return array<string, array<string, array<string, string>>>
+     */
+    public function getAutoloaderConfig(): array
     {
         return [
             StandardAutoloader::class => [

--- a/test/assets/module/LaminasTestApiToolsDbMongo/src/LaminasTestApiToolsDbMongo/Document/Meta.php
+++ b/test/assets/module/LaminasTestApiToolsDbMongo/src/LaminasTestApiToolsDbMongo/Document/Meta.php
@@ -22,7 +22,10 @@ class Meta
         return $this->name;
     }
 
-    public function setName($value)
+    /**
+     * @return static
+     */
+    public function setName(string $value): self
     {
         $this->name = $value;
 
@@ -36,12 +39,17 @@ class Meta
         return $this->createdAt;
     }
 
-    public function setCreatedAt(DateTime $value)
+    public function setCreatedAt(DateTime $value): void
     {
         $this->createdAt = $value;
     }
 
-    public function getArrayCopy()
+    /**
+     * @return array
+     *
+     * @psalm-return array{name: mixed, createdAt: mixed}
+     */
+    public function getArrayCopy(): array
     {
         return [
             'name'      => $this->getName(),
@@ -49,7 +57,7 @@ class Meta
         ];
     }
 
-    public function exchangeArray($values)
+    public function exchangeArray($values): void
     {
         $this->setName($values['name'] ?? null);
         $this->setCreatedAt($values['createdAt'] ?? null);

--- a/test/assets/module/LaminasTestApiToolsDbMongo/src/LaminasTestApiToolsDbMongo/Module.php
+++ b/test/assets/module/LaminasTestApiToolsDbMongo/src/LaminasTestApiToolsDbMongo/Module.php
@@ -14,7 +14,11 @@ class Module implements ApiToolsProviderInterface
         return include __DIR__ . '/../../config/module.config.php';
     }
 
-    public function getAutoloaderConfig()
+    /**
+     * @return string[][][]
+     * @psalm-return array<string, array<string, array<string, string>>>
+     */
+    public function getAutoloaderConfig(): array
     {
         return [
             StandardAutoloader::class => [

--- a/test/assets/module/LaminasTestApiToolsDbMongoApi/src/LaminasTestApiToolsDbMongoApi/Module.php
+++ b/test/assets/module/LaminasTestApiToolsDbMongoApi/src/LaminasTestApiToolsDbMongoApi/Module.php
@@ -9,12 +9,21 @@ use Laminas\Loader\StandardAutoloader;
 
 class Module implements ApiToolsProviderInterface
 {
-    public function getConfig()
+    /**
+     * @return array
+     *
+     * @psalm-return array<empty, empty>
+     */
+    public function getConfig(): array
     {
         return include __DIR__ . '/../../config/module.config.php';
     }
 
-    public function getAutoloaderConfig()
+    /**
+     * @return string[][][]
+     * @psalm-return array<string, array<string, array<string, string>>>
+     */
+    public function getAutoloaderConfig(): array
     {
         return [
             StandardAutoloader::class => [

--- a/test/assets/module/LaminasTestApiToolsGeneral/src/LaminasTestApiToolsGeneral/Listener/EventCatcher.php
+++ b/test/assets/module/LaminasTestApiToolsGeneral/src/LaminasTestApiToolsGeneral/Listener/EventCatcher.php
@@ -21,7 +21,7 @@ class EventCatcher
     /** @var array */
     protected $caughtEvents = [];
 
-    public function attachShared(SharedEventManagerInterface $events)
+    public function attachShared(SharedEventManagerInterface $events): void
     {
         $listener = $events->attach(self::EVENT_IDENTIFIER, '*', [$this, 'listen']);
 
@@ -32,7 +32,7 @@ class EventCatcher
         $this->listeners[] = $listener;
     }
 
-    public function detachShared(SharedEventManagerInterface $events)
+    public function detachShared(SharedEventManagerInterface $events): void
     {
         $eventManagerVersion = method_exists($events, 'getEvents') ? 2 : 3;
 
@@ -52,7 +52,7 @@ class EventCatcher
         }
     }
 
-    public function listen(Event $e)
+    public function listen(Event $e): void
     {
         $this->caughtEvents[] = $e->getName();
         array_unique($this->caughtEvents);

--- a/test/assets/module/LaminasTestApiToolsGeneral/src/LaminasTestApiToolsGeneral/Module.php
+++ b/test/assets/module/LaminasTestApiToolsGeneral/src/LaminasTestApiToolsGeneral/Module.php
@@ -17,7 +17,11 @@ class Module implements ApiToolsProviderInterface, BootstrapListenerInterface
         return include __DIR__ . '/../../config/module.config.php';
     }
 
-    public function getAutoloaderConfig()
+    /**
+     * @return string[][][]
+     * @psalm-return array<string, array<string, array<string, string>>>
+     */
+    public function getAutoloaderConfig(): array
     {
         return [
             StandardAutoloader::class => [
@@ -31,7 +35,7 @@ class Module implements ApiToolsProviderInterface, BootstrapListenerInterface
     /**
      * Add the event catcher
      *
-     * @return array
+     * @return void
      */
     public function onBootstrap(EventInterface $e)
     {

--- a/test/src/Admin/Controller/DoctrineAutodiscoveryControllerFactoryTest.php
+++ b/test/src/Admin/Controller/DoctrineAutodiscoveryControllerFactoryTest.php
@@ -34,7 +34,7 @@ class DoctrineAutodiscoveryControllerFactoryTest extends TestCase
         $this->container->get(DoctrineAutodiscoveryModel::class)->willReturn($this->model);
     }
 
-    public function testInvokableFactoryReturnsDoctrineAutodiscoveryController()
+    public function testInvokableFactoryReturnsDoctrineAutodiscoveryController(): void
     {
         $factory    = new DoctrineAutodiscoveryControllerFactory();
         $controller = $factory($this->container->reveal(), DoctrineAutodiscoveryController::class);
@@ -43,7 +43,7 @@ class DoctrineAutodiscoveryControllerFactoryTest extends TestCase
         $this->assertAttributeSame($this->model, 'model', $controller);
     }
 
-    public function testLegacyFactoryReturnsDoctrineAutodiscoveryController()
+    public function testLegacyFactoryReturnsDoctrineAutodiscoveryController(): void
     {
         $controllers = $this->prophesize(AbstractPluginManager::class);
         $controllers->getServiceLocator()->willReturn($this->container->reveal());

--- a/test/src/Admin/Model/DoctrineAutodiscoveryModelFactoryTest.php
+++ b/test/src/Admin/Model/DoctrineAutodiscoveryModelFactoryTest.php
@@ -30,7 +30,7 @@ class DoctrineAutodiscoveryModelFactoryTest extends TestCase
         $this->container->willImplement(ContainerInterface::class);
     }
 
-    public function testFactoryRaisesExceptionIfConfigServiceIsMissing()
+    public function testFactoryRaisesExceptionIfConfigServiceIsMissing(): void
     {
         $factory = new DoctrineAutodiscoveryModelFactory();
 
@@ -41,7 +41,7 @@ class DoctrineAutodiscoveryModelFactoryTest extends TestCase
         $factory($this->container->reveal());
     }
 
-    public function testFactoryReturnsDoctrineAutodiscoveryModelComposingConfigAndContainer()
+    public function testFactoryReturnsDoctrineAutodiscoveryModelComposingConfigAndContainer(): void
     {
         $factory = new DoctrineAutodiscoveryModelFactory();
 

--- a/test/src/Admin/Model/DoctrineAutodiscoveryModelTest.php
+++ b/test/src/Admin/Model/DoctrineAutodiscoveryModelTest.php
@@ -16,7 +16,7 @@ use function usort;
 
 class DoctrineAutodiscoveryModelTest extends TestCase
 {
-    public function testORMAutodiscoveryEntitiesWithFields()
+    public function testORMAutodiscoveryEntitiesWithFields(): void
     {
         $this->setApplicationConfig(
             include __DIR__ . '/../../../config/ORM/application.config.php'
@@ -47,7 +47,7 @@ class DoctrineAutodiscoveryModelTest extends TestCase
         $this->assertCount(1, $result[2]['fields']);
     }
 
-    public function testODMAutodiscoveryEntitiesWithFields()
+    public function testODMAutodiscoveryEntitiesWithFields(): void
     {
         $this->setApplicationConfig(
             include __DIR__ . '/../../../config/ODM/application.config.php'

--- a/test/src/Admin/Model/DoctrineMetadata1Test.php
+++ b/test/src/Admin/Model/DoctrineMetadata1Test.php
@@ -35,10 +35,10 @@ class DoctrineMetadata1Test extends TestCase
     /**
      * @see https://github.com/zfcampus/zf-apigility/issues/18
      */
-    public function testDoctrineMetadataResource()
+    public function testDoctrineMetadataResource(): void
     {
         $serviceManager = $this->getApplication()->getServiceManager();
-        $em             = $serviceManager->get('doctrine.entitymanager.orm_default');
+        $serviceManager->get('doctrine.entitymanager.orm_default');
 
         $this->getRequest()->getHeaders()->addHeaders([
             'Accept' => 'application/json',
@@ -57,13 +57,13 @@ class DoctrineMetadata1Test extends TestCase
         $this->assertArrayHasKey('_embedded', $body);
     }
 
-    public function testDoctrineService()
+    public function testDoctrineService(): void
     {
         $serviceManager = $this->getApplication()->getServiceManager();
         $em             = $serviceManager->get('doctrine.entitymanager.orm_default');
 
         $tool = new SchemaTool($em);
-        $res  = $tool->createSchema($em->getMetadataFactory()->getAllMetadata());
+        $tool->createSchema($em->getMetadataFactory()->getAllMetadata());
 
         // Create DB
         $resourceDefinition = [

--- a/test/src/Admin/Model/DoctrineMetadata2Test.php
+++ b/test/src/Admin/Model/DoctrineMetadata2Test.php
@@ -31,10 +31,10 @@ class DoctrineMetadata2Test extends TestCase
     /**
      * @see https://github.com/zfcampus/zf-apigility/issues/18
      */
-    public function testDoctrineService()
+    public function testDoctrineService(): void
     {
         $serviceManager = $this->getApplication()->getServiceManager();
-        $em             = $serviceManager->get('doctrine.entitymanager.orm_default');
+        $serviceManager->get('doctrine.entitymanager.orm_default');
 
         $this->getRequest()->getHeaders()->addHeaders([
             'Accept' => 'application/json',
@@ -66,7 +66,7 @@ class DoctrineMetadata2Test extends TestCase
         $this->resource->setModuleName('DbApi');
         $this->assertEquals($this->resource->getModuleName(), 'DbApi');
 
-        $entity = $this->resource->patch(
+        $this->resource->patch(
             'DbApi\\V1\\Rest\\Artist\\Controller',
             [
                 'routematch'             => '/doctrine-changed/test',

--- a/test/src/Admin/Model/DoctrineMetadataServiceResourceFactoryTest.php
+++ b/test/src/Admin/Model/DoctrineMetadataServiceResourceFactoryTest.php
@@ -25,7 +25,7 @@ class DoctrineMetadataServiceResourceFactoryTest extends TestCase
         $this->container = $this->prophesize(ServiceManager::class);
     }
 
-    public function testFactoryReturnsDoctrineMetadataServiceResource()
+    public function testFactoryReturnsDoctrineMetadataServiceResource(): void
     {
         $factory = new DoctrineMetadataServiceResourceFactory();
 

--- a/test/src/Admin/Model/DoctrineRestServiceModelFactoryFactoryTest.php
+++ b/test/src/Admin/Model/DoctrineRestServiceModelFactoryFactoryTest.php
@@ -84,7 +84,7 @@ class DoctrineRestServiceModelFactoryFactoryTest extends TestCase
     /**
      * @dataProvider missingDependencies
      */
-    public function testFactoryRaisesExceptionIfDependenciesAreMissing(array $dependencies)
+    public function testFactoryRaisesExceptionIfDependenciesAreMissing(array $dependencies): void
     {
         $factory = new DoctrineRestServiceModelFactoryFactory();
 
@@ -97,7 +97,7 @@ class DoctrineRestServiceModelFactoryFactoryTest extends TestCase
         $factory($this->container->reveal());
     }
 
-    public function testFactoryReturnsConfiguredDoctrineRestServiceModelFactory()
+    public function testFactoryReturnsConfiguredDoctrineRestServiceModelFactory(): void
     {
         $factory               = new DoctrineRestServiceModelFactoryFactory();
         $pathSpec              = $this->prophesize(ModulePathSpec::class)->reveal();

--- a/test/src/Admin/Model/DoctrineRestServiceResourceFactoryTest.php
+++ b/test/src/Admin/Model/DoctrineRestServiceResourceFactoryTest.php
@@ -31,7 +31,12 @@ class DoctrineRestServiceResourceFactoryTest extends TestCase
         $this->container = $this->prophesize(ContainerInterface::class);
     }
 
-    /** @psalm-return array<string, array{0: array<class-string, bool>}> */
+    /**
+     * @return bool[][][]
+     * @psalm-return array<string, array{
+     *     0: array<class-string, bool>
+     * }>
+     */
     public function missingDependencies(): array
     {
         return [
@@ -69,7 +74,7 @@ class DoctrineRestServiceResourceFactoryTest extends TestCase
     /**
      * @dataProvider missingDependencies
      */
-    public function testFactoryRaisesExceptionIfDependenciesAreMissing(array $dependencies)
+    public function testFactoryRaisesExceptionIfDependenciesAreMissing(array $dependencies): void
     {
         $factory = new DoctrineRestServiceResourceFactory();
 
@@ -82,7 +87,7 @@ class DoctrineRestServiceResourceFactoryTest extends TestCase
         $factory($this->container->reveal());
     }
 
-    public function testFactoryReturnsConfiguredDoctrineRestServiceResource()
+    public function testFactoryReturnsConfiguredDoctrineRestServiceResource(): void
     {
         $factory            = new DoctrineRestServiceResourceFactory();
         $restFactory        = $this->prophesize(DoctrineRestServiceModelFactory::class)->reveal();

--- a/test/src/Admin/Model/DoctrineRestServiceResourceTest.php
+++ b/test/src/Admin/Model/DoctrineRestServiceResourceTest.php
@@ -11,8 +11,6 @@ use Laminas\ApiTools\Doctrine\Admin\Model\DoctrineRestServiceEntity;
 use Laminas\ApiTools\Doctrine\Admin\Model\DoctrineRestServiceResource;
 use LaminasTest\ApiTools\Doctrine\TestCase;
 
-use function print_r;
-
 class DoctrineRestServiceResourceTest extends TestCase
 {
     protected function setUp(): void
@@ -33,12 +31,12 @@ class DoctrineRestServiceResourceTest extends TestCase
     /**
      * @see https://github.com/zfcampus/zf-apigility/issues/18
      */
-    public function testCreateReturnsRestServiceEntityWithControllerServiceNamePopulated()
+    public function testCreateReturnsRestServiceEntityWithControllerServiceNamePopulated(): void
     {
         $serviceManager = $this->getApplication()->getServiceManager();
         $em             = $serviceManager->get('doctrine.entitymanager.orm_default');
 
-        $tool = new SchemaTool($em);
+        new SchemaTool($em);
 
         // Create DB
         $resourceDefinition = [
@@ -76,10 +74,8 @@ class DoctrineRestServiceResourceTest extends TestCase
             ]
         );
 
-        $x = $this->dispatch('/db-api/artist');
+        $this->dispatch('/db-api/artist');
 
         $this->resource->delete('DbApi\\V1\\Rest\\Artist\\Controller');
-
-        print_r($x);
     }
 }

--- a/test/src/Admin/Model/DoctrineRpcServiceModelFactoryFactoryTest.php
+++ b/test/src/Admin/Model/DoctrineRpcServiceModelFactoryFactoryTest.php
@@ -83,7 +83,7 @@ class DoctrineRpcServiceModelFactoryFactoryTest extends TestCase
     /**
      * @dataProvider missingDependencies
      */
-    public function testFactoryRaisesExceptionIfDependenciesAreMissing(array $dependencies)
+    public function testFactoryRaisesExceptionIfDependenciesAreMissing(array $dependencies): void
     {
         $factory = new DoctrineRpcServiceModelFactoryFactory();
 
@@ -96,7 +96,7 @@ class DoctrineRpcServiceModelFactoryFactoryTest extends TestCase
         $factory($this->container->reveal());
     }
 
-    public function testFactoryReturnsConfiguredDoctrineRpcServiceModelFactory()
+    public function testFactoryReturnsConfiguredDoctrineRpcServiceModelFactory(): void
     {
         $factory               = new DoctrineRpcServiceModelFactoryFactory();
         $pathSpec              = $this->prophesize(ModulePathSpec::class)->reveal();

--- a/test/src/Admin/Model/DoctrineRpcServiceResourceFactoryTest.php
+++ b/test/src/Admin/Model/DoctrineRpcServiceResourceFactoryTest.php
@@ -82,7 +82,7 @@ class DoctrineRpcServiceResourceFactoryTest extends TestCase
     /**
      * @dataProvider missingDependencies
      */
-    public function testFactoryRaisesExceptionIfDependenciesAreMissing(array $dependencies)
+    public function testFactoryRaisesExceptionIfDependenciesAreMissing(array $dependencies): void
     {
         $factory = new DoctrineRpcServiceResourceFactory();
 
@@ -95,7 +95,7 @@ class DoctrineRpcServiceResourceFactoryTest extends TestCase
         $factory($this->container->reveal());
     }
 
-    public function testFactoryReturnsConfiguredDoctrineRpcServiceResource()
+    public function testFactoryReturnsConfiguredDoctrineRpcServiceResource(): void
     {
         $factory            = new DoctrineRpcServiceResourceFactory();
         $rpcFactory         = $this->prophesize(DoctrineRpcServiceModelFactory::class)->reveal();

--- a/test/src/Server/ODM/CRUD/CRUDTest.php
+++ b/test/src/Server/ODM/CRUD/CRUDTest.php
@@ -47,7 +47,7 @@ class CRUDTest extends TestCase
         parent::tearDown();
     }
 
-    protected function buildODMApi()
+    protected function buildODMApi(): void
     {
         $serviceManager = $this->getApplication()->getServiceManager();
 
@@ -74,7 +74,7 @@ class CRUDTest extends TestCase
         $this->dm       = $serviceManager->get('doctrine.documentmanager.odm_default');
     }
 
-    protected function clearData()
+    protected function clearData(): void
     {
         $config = $this->getApplication()->getConfig();
         $config = $config['doctrine']['connection']['odm_default'];
@@ -85,7 +85,7 @@ class CRUDTest extends TestCase
         $collection->remove();
     }
 
-    public function testCreate()
+    public function testCreate(): void
     {
         $this->getRequest()->getHeaders()->addHeaderLine('Accept', 'application/json');
 
@@ -107,7 +107,7 @@ class CRUDTest extends TestCase
         ]);
     }
 
-    public function testCreateWithListenerThatReturnsApiProblem()
+    public function testCreateWithListenerThatReturnsApiProblem(): void
     {
         $sharedEvents = $this->getApplication()->getEventManager()->getSharedManager();
         $sharedEvents->attach(
@@ -132,7 +132,7 @@ class CRUDTest extends TestCase
         $this->assertEquals('LaminasTestCreateFailure', $body['detail']);
     }
 
-    public function testCreateByExplicitlySettingEntityFactoryInConstructor()
+    public function testCreateByExplicitlySettingEntityFactoryInConstructor(): void
     {
         /** @var InstantiatorInterface|PHPUnit_Framework_MockObject_MockObject $entityFactoryMock */
         $entityFactoryMock = $this->getMockBuilder(InstantiatorInterface::class)->getMock();
@@ -182,7 +182,7 @@ class CRUDTest extends TestCase
         ]);
     }
 
-    public function testFetch()
+    public function testFetch(): void
     {
         $meta = $this->createMeta('Meta Fetch');
         $this->getRequest()->getHeaders()->addHeaderLine('Accept', 'application/json');
@@ -199,7 +199,7 @@ class CRUDTest extends TestCase
         ]);
     }
 
-    public function testFetchWithListenerThatReturnsApiProblem()
+    public function testFetchWithListenerThatReturnsApiProblem(): void
     {
         $meta         = $this->createMeta('Meta Fetch ApiProblem');
         $sharedEvents = $this->getApplication()->getEventManager()->getSharedManager();
@@ -222,7 +222,7 @@ class CRUDTest extends TestCase
         $this->assertEquals('LaminasTestFetchFailure', $body['detail']);
     }
 
-    public function testFetchAll()
+    public function testFetchAll(): void
     {
         $meta1 = $this->createMeta('Meta 1');
         $meta2 = $this->createMeta('Meta 2');
@@ -243,7 +243,7 @@ class CRUDTest extends TestCase
         ]);
     }
 
-    public function testFetchAllEmptyCollection()
+    public function testFetchAllEmptyCollection(): void
     {
         $this->getRequest()->getHeaders()->addHeaderLine('Accept', 'application/json');
         $this->getRequest()->setMethod(Request::METHOD_GET);
@@ -260,7 +260,7 @@ class CRUDTest extends TestCase
         ]);
     }
 
-    public function testFetchAllWithListenerThatReturnsApiProblem()
+    public function testFetchAllWithListenerThatReturnsApiProblem(): void
     {
         $this->createMeta('Meta FetchAll ApiProblem');
         $sharedEvents = $this->getApplication()->getEventManager()->getSharedManager();
@@ -282,7 +282,7 @@ class CRUDTest extends TestCase
         $this->assertEquals('LaminasTestFetchAllFailure', $body['detail']);
     }
 
-    public function testPatch()
+    public function testPatch(): void
     {
         $meta = $this->createMeta('Meta Patch');
         $this->getRequest()->getHeaders()->addHeaders([
@@ -306,7 +306,7 @@ class CRUDTest extends TestCase
         ]);
     }
 
-    public function testPatchWithListenerThatReturnsApiProblem()
+    public function testPatchWithListenerThatReturnsApiProblem(): void
     {
         $meta         = $this->createMeta('Meta Patch ApiProblem');
         $sharedEvents = $this->getApplication()->getEventManager()->getSharedManager();
@@ -333,7 +333,7 @@ class CRUDTest extends TestCase
         $this->assertEquals('LaminasTestPatchFailure', $body['detail']);
     }
 
-    public function testPut()
+    public function testPut(): void
     {
         $meta = $this->createMeta('Meta Put');
         $this->getRequest()->getHeaders()->addHeaders([
@@ -360,7 +360,7 @@ class CRUDTest extends TestCase
         ]);
     }
 
-    public function testPutWithListenerThatReturnsApiProblem()
+    public function testPutWithListenerThatReturnsApiProblem(): void
     {
         $meta         = $this->createMeta('Meta Put ApiProblem');
         $sharedEvents = $this->getApplication()->getEventManager()->getSharedManager();
@@ -390,7 +390,7 @@ class CRUDTest extends TestCase
         $this->assertEquals('LaminasTestPutFailure', $body['detail']);
     }
 
-    public function testDelete()
+    public function testDelete(): void
     {
         $meta = $this->createMeta('Meta Delete');
         $id   = $meta->getId();
@@ -407,7 +407,7 @@ class CRUDTest extends TestCase
         ]);
     }
 
-    public function testDeleteWithListenerThatReturnsApiProblem()
+    public function testDeleteWithListenerThatReturnsApiProblem(): void
     {
         $meta         = $this->createMeta('Meta Delete ApiProblem');
         $sharedEvents = $this->getApplication()->getEventManager()->getSharedManager();
@@ -432,7 +432,7 @@ class CRUDTest extends TestCase
         $this->assertEquals($meta->getId(), $foundEntity->getId());
     }
 
-    public function testDeleteEntityNotFound()
+    public function testDeleteEntityNotFound(): void
     {
         $meta = $this->createMeta();
         $id   = $meta->getId() . '0';
@@ -446,7 +446,7 @@ class CRUDTest extends TestCase
         $this->assertNull($this->dm->getRepository(Meta::class)->find($id));
     }
 
-    public function testDeleteEntityDeleted()
+    public function testDeleteEntityDeleted(): void
     {
         $meta = $this->createMeta();
         $id   = $meta->getId();
@@ -465,7 +465,7 @@ class CRUDTest extends TestCase
     /**
      * @param array $expectedEvents
      */
-    protected function validateTriggeredEvents(array $expectedEvents)
+    protected function validateTriggeredEvents(array $expectedEvents): void
     {
         $serviceManager = $this->getApplication()->getServiceManager();
         $eventCatcher   = $serviceManager->get(EventCatcher::class);

--- a/test/src/Server/ORM/CRUD/CRUDTest.php
+++ b/test/src/Server/ORM/CRUD/CRUDTest.php
@@ -53,7 +53,7 @@ class CRUDTest extends TestCase
         $this->buildORMApi();
     }
 
-    protected function buildORMApi()
+    protected function buildORMApi(): void
     {
         $serviceManager = $this->getApplication()->getServiceManager();
         /** @var EntityManager $em */
@@ -183,7 +183,7 @@ class CRUDTest extends TestCase
         $this->em = $em;
     }
 
-    public function testCreate()
+    public function testCreate(): void
     {
         $this->getRequest()->getHeaders()->addHeaderLine('Accept', 'application/json');
 
@@ -205,7 +205,7 @@ class CRUDTest extends TestCase
         ]);
     }
 
-    public function testCreateWithRelation()
+    public function testCreateWithRelation(): void
     {
         $artist = $this->createArtist();
         $this->getRequest()->getHeaders()->addHeaderLine('Accept', 'application/json');
@@ -231,7 +231,7 @@ class CRUDTest extends TestCase
      * @param string $method
      * @param string $message
      */
-    public function testCreateWithListenerThatReturnsApiProblem($method, $message)
+    public function testCreateWithListenerThatReturnsApiProblem($method, $message): void
     {
         $this->$method(DoctrineResourceEvent::EVENT_CREATE_PRE);
         $this->getRequest()->getHeaders()->addHeaderLine('Accept', 'application/json');
@@ -254,7 +254,7 @@ class CRUDTest extends TestCase
         );
     }
 
-    public function testFetchByCustomIdField()
+    public function testFetchByCustomIdField(): void
     {
         $product = $this->createProduct();
 
@@ -275,7 +275,7 @@ class CRUDTest extends TestCase
     /**
      * @see https://github.com/zfcampus/zf-apigility-doctrine/pull/316
      */
-    public function testFetchByCustomIdFieldIncludesApiToolsResourceEventInDoctrineResourceEvent()
+    public function testFetchByCustomIdFieldIncludesApiToolsResourceEventInDoctrineResourceEvent(): void
     {
         $product = $this->createProduct();
 
@@ -299,7 +299,7 @@ class CRUDTest extends TestCase
         $this->assertTrue($spy->caught, 'EVENT_FETCH_PRE listener was not triggered');
     }
 
-    public function testFetchEntityWithVersionFieldWithVersionParamInPath()
+    public function testFetchEntityWithVersionFieldWithVersionParamInPath(): void
     {
         $product = $this->createProduct();
 
@@ -318,7 +318,7 @@ class CRUDTest extends TestCase
         ]);
     }
 
-    public function testFetchByCustomIdFieldWithInvalidIdValue()
+    public function testFetchByCustomIdFieldWithInvalidIdValue(): void
     {
         $product = $this->createProduct();
 
@@ -331,7 +331,7 @@ class CRUDTest extends TestCase
         $this->validateTriggeredEvents([DoctrineResourceEvent::EVENT_FETCH_PRE]);
     }
 
-    public function testCreateByExplicitlySettingEntityFactoryInConstructor()
+    public function testCreateByExplicitlySettingEntityFactoryInConstructor(): void
     {
         /** @var InstantiatorInterface|PHPUnit_Framework_MockObject_MockObject $entityFactoryMock */
         $entityFactoryMock = $this->getMockBuilder(InstantiatorInterface::class)->getMock();
@@ -375,7 +375,7 @@ class CRUDTest extends TestCase
         $this->assertResponseStatusCode(201);
     }
 
-    public function testFetch()
+    public function testFetch(): void
     {
         $artist = $this->createArtist('Artist Name');
         $this->getRequest()->getHeaders()->addHeaderLine('Accept', 'application/json');
@@ -392,7 +392,7 @@ class CRUDTest extends TestCase
         ]);
     }
 
-    public function testFetchWithNonPrimaryKeyIdentifier()
+    public function testFetchWithNonPrimaryKeyIdentifier(): void
     {
         $artist = $this->createArtist('ArtistTwo');
         $this->getRequest()->getHeaders()->addHeaderLine('Accept', 'application/json');
@@ -405,7 +405,7 @@ class CRUDTest extends TestCase
         $this->assertEquals('ArtistTwo', $body['name']);
     }
 
-    public function testFetchWithRelation()
+    public function testFetchWithRelation(): void
     {
         $artist = $this->createArtist('NewArtist');
         $album  = $this->createAlbum('NewAlbum', $artist);
@@ -424,7 +424,7 @@ class CRUDTest extends TestCase
      * @param string $method
      * @param string $message
      */
-    public function testFetchWithListenerThatReturnsApiProblem($method, $message)
+    public function testFetchWithListenerThatReturnsApiProblem($method, $message): void
     {
         $artist = $this->createArtist('Artist Fetch ApiProblem');
         $this->$method(DoctrineResourceEvent::EVENT_FETCH_PRE);
@@ -441,7 +441,7 @@ class CRUDTest extends TestCase
         );
     }
 
-    public function testFetchAll()
+    public function testFetchAll(): void
     {
         $artist1 = $this->createArtist('Artist 1');
         $artist2 = $this->createArtist('Artist 2');
@@ -462,7 +462,7 @@ class CRUDTest extends TestCase
         ]);
     }
 
-    public function testFetchAllEmptyCollection()
+    public function testFetchAllEmptyCollection(): void
     {
         $this->getRequest()->getHeaders()->addHeaderLine('Accept', 'application/json');
         $this->getRequest()->setMethod(Request::METHOD_GET);
@@ -484,7 +484,7 @@ class CRUDTest extends TestCase
      * @param string $method
      * @param string $message
      */
-    public function testFetchAllWithListenerThatReturnsApiProblem($method, $message)
+    public function testFetchAllWithListenerThatReturnsApiProblem($method, $message): void
     {
         $this->createArtist('Artist FetchAll ApiProblem');
         $this->$method(DoctrineResourceEvent::EVENT_FETCH_ALL_PRE);
@@ -501,7 +501,7 @@ class CRUDTest extends TestCase
         );
     }
 
-    public function testPatch()
+    public function testPatch(): void
     {
         $artist = $this->createArtist('Artist Patch');
         $this->getRequest()->getHeaders()->addHeaders([
@@ -530,7 +530,7 @@ class CRUDTest extends TestCase
      * @param string $method
      * @param string $message
      */
-    public function testPatchWithListenerThatReturnsApiProblem($method, $message)
+    public function testPatchWithListenerThatReturnsApiProblem($method, $message): void
     {
         $artist = $this->createArtist('Artist Patch ApiProblem');
         $this->$method(DoctrineResourceEvent::EVENT_PATCH_PRE);
@@ -552,7 +552,7 @@ class CRUDTest extends TestCase
         );
     }
 
-    public function testPatchList()
+    public function testPatchList(): void
     {
         $artist1 = $this->createArtist('Artist Patch List 1');
         $artist2 = $this->createArtist('Artist Patch List 2');
@@ -600,7 +600,7 @@ class CRUDTest extends TestCase
      * @param string $method
      * @param string $message
      */
-    public function testPatchListWithListenerThatReturnsApiProblem($method, $message)
+    public function testPatchListWithListenerThatReturnsApiProblem($method, $message): void
     {
         $artist = $this->createArtist('Artist Patch List ApiProblem');
         $this->$method(DoctrineResourceEvent::EVENT_PATCH_LIST_PRE);
@@ -627,7 +627,7 @@ class CRUDTest extends TestCase
         );
     }
 
-    public function testPut()
+    public function testPut(): void
     {
         $artist = $this->createArtist('Artist Put');
         $this->getRequest()->getHeaders()->addHeaders([
@@ -659,7 +659,7 @@ class CRUDTest extends TestCase
      * @param string $method
      * @param string $message
      */
-    public function testPutWithListenerThatReturnsApiProblem($method, $message)
+    public function testPutWithListenerThatReturnsApiProblem($method, $message): void
     {
         $artist = $this->createArtist('Artist Put ApiProblem');
         $this->$method(DoctrineResourceEvent::EVENT_UPDATE_PRE);
@@ -684,7 +684,7 @@ class CRUDTest extends TestCase
         );
     }
 
-    public function testDelete()
+    public function testDelete(): void
     {
         $artist = $this->createArtist('Artist Delete');
         $id     = $artist->getId();
@@ -706,7 +706,7 @@ class CRUDTest extends TestCase
      * @param string $method
      * @param string $message
      */
-    public function testDeleteWithListenerThatReturnsApiProblem($method, $message)
+    public function testDeleteWithListenerThatReturnsApiProblem($method, $message): void
     {
         $artist = $this->createArtist('Artist Delete ApiProblem');
         $this->$method(DoctrineResourceEvent::EVENT_DELETE_PRE);
@@ -726,7 +726,7 @@ class CRUDTest extends TestCase
         $this->assertEquals($artist->getId(), $foundEntity->getId());
     }
 
-    public function testDeleteEntityNotFound()
+    public function testDeleteEntityNotFound(): void
     {
         $artist = $this->createArtist();
         $id     = $artist->getId() + 1;
@@ -740,7 +740,7 @@ class CRUDTest extends TestCase
         $this->assertNull($this->em->getRepository(Artist::class)->find($id));
     }
 
-    public function testDeleteEntityDeleted()
+    public function testDeleteEntityDeleted(): void
     {
         $artist = $this->createArtist();
         $id     = $artist->getId();
@@ -756,7 +756,7 @@ class CRUDTest extends TestCase
         $this->assertNull($this->em->getRepository(Artist::class)->find($id));
     }
 
-    public function testDeleteList()
+    public function testDeleteList(): void
     {
         $artist1 = $this->createArtist('Artist Delete 1');
         $artist2 = $this->createArtist('Artist Delete 2');
@@ -794,7 +794,7 @@ class CRUDTest extends TestCase
      * @param string $method
      * @param string $message
      */
-    public function testDeleteListWithListenerThatReturnsApiProblem($method, $message)
+    public function testDeleteListWithListenerThatReturnsApiProblem($method, $message): void
     {
         $this->$method(DoctrineResourceEvent::EVENT_DELETE_LIST_PRE);
 
@@ -834,6 +834,10 @@ class CRUDTest extends TestCase
         $this->assertEquals($artist3->getId(), $foundEntity3->getId());
     }
 
+    /**
+     * @return void
+     * @psalm-return never
+     */
     public function testGetRpcNoParams()
     {
         $this->markTestIncomplete('Doctrine RPC Services are not fully implemented.');
@@ -846,6 +850,10 @@ class CRUDTest extends TestCase
         print_r($body);
     }
 
+    /**
+     * @return void
+     * @psalm-return never
+     */
     public function testGetRpcWithParams()
     {
         $this->markTestIncomplete('Doctrine RPC Services are not fully implemented.');
@@ -864,7 +872,7 @@ class CRUDTest extends TestCase
     /**
      * @param array $expectedEvents
      */
-    protected function validateTriggeredEvents(array $expectedEvents)
+    protected function validateTriggeredEvents(array $expectedEvents): void
     {
         $serviceManager = $this->getApplication()->getServiceManager();
         $eventCatcher   = $serviceManager->get(EventCatcher::class);
@@ -875,7 +883,7 @@ class CRUDTest extends TestCase
     /**
      * @param array $expectedEvents
      */
-    protected function validateTriggeredEventsContains(array $expectedEvents)
+    protected function validateTriggeredEventsContains(array $expectedEvents): void
     {
         $serviceManager = $this->getApplication()->getServiceManager();
         $eventCatcher   = $serviceManager->get(EventCatcher::class);

--- a/test/src/Server/Validator/NoObjectExistsFactoryTest.php
+++ b/test/src/Server/Validator/NoObjectExistsFactoryTest.php
@@ -40,7 +40,7 @@ class NoObjectExistsFactoryTest extends TestCase
         $this->validators = new ValidatorPluginManager($this->serviceManager->reveal(), $validatorsConfig);
     }
 
-    public function testCreate()
+    public function testCreate(): void
     {
         $validator = $this->validators->get(
             NoObjectExists::class,
@@ -53,7 +53,7 @@ class NoObjectExistsFactoryTest extends TestCase
         $this->assertInstanceOf(NoObjectExistsOrigin::class, $validator);
     }
 
-    public function testCreateWithEntityClassProvided()
+    public function testCreateWithEntityClassProvided(): void
     {
         $entityManager = $this->prophesize(EntityManager::class);
         $entityManager->getRepository('MyEntity')->willReturn($this->objectRepository->reveal());

--- a/test/src/Server/Validator/ObjectExistsFactoryTest.php
+++ b/test/src/Server/Validator/ObjectExistsFactoryTest.php
@@ -40,7 +40,7 @@ class ObjectExistsFactoryTest extends TestCase
         $this->validators = new ValidatorPluginManager($this->serviceManager->reveal(), $validatorsConfig);
     }
 
-    public function testCreate()
+    public function testCreate(): void
     {
         $validator = $this->validators->get(
             ObjectExists::class,
@@ -53,7 +53,7 @@ class ObjectExistsFactoryTest extends TestCase
         $this->assertInstanceOf(ObjectExistsOrigin::class, $validator);
     }
 
-    public function testCreateWithEntityClassProvided()
+    public function testCreateWithEntityClassProvided(): void
     {
         $entityManager = $this->prophesize(EntityManager::class);
         $entityManager->getRepository('MyEntity')->willReturn($this->objectRepository->reveal());

--- a/test/src/TestCase.php
+++ b/test/src/TestCase.php
@@ -64,7 +64,7 @@ class TestCase extends AbstractHttpControllerTestCase
         rmdir($dir);
     }
 
-    private function clearAssets()
+    private function clearAssets(): void
     {
         foreach ($this->enabledModules as $module => $path) {
             $configPath = sprintf('%s/config/', $path);


### PR DESCRIPTION
This patch builds off the current 2.4.x state, which includes:

- Usage of GHA for CI
- Updating minimum PHP version to 7.3, and adding 8.0
- Updating to laminas-coding-standard 2.3
- Updating to PHPUnit 9.5

As such, this forms a better basis for adding Psalm support. This patch:

- Adds Psalm (and its PHPUnit plugin) as a dev requirement, along with configuration.
- Applies automated fixes and suggestions from Psalm, and creates the initial baseline.

Fixes #16
Replaces #18
