### PR TITLE
Fix spelling mistake in comment

### DIFF
--- a/src/Server/Resource/DoctrineResource.php
+++ b/src/Server/Resource/DoctrineResource.php
@@ -649,7 +649,7 @@ class DoctrineResource extends AbstractResourceListener implements
     }
 
     /**
-     * This method will give custom listeners te chance to alter entities / collections.
+     * This method will give custom listeners the chance to alter entities / collections.
      * Listeners can also return an ApiProblem, which will be returned immediately.
      * It is also possible to throw Exceptions, which will result in an ApiProblem eventually.
      *


### PR DESCRIPTION
Small fix to comment spelling in order to get up and running on laminas-api-tools contributions